### PR TITLE
【Environment】C#ManagedPlugins追加

### DIFF
--- a/Client/Assets/Plugins/ManagedPlugins.meta
+++ b/Client/Assets/Plugins/ManagedPlugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c0eba4c6444d9e1449da6570a3a667f4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ManagedPlugins/.gitignore
+++ b/ManagedPlugins/.gitignore
@@ -1,0 +1,4 @@
+# binとobjは不要
+ManagedPlugins/bin
+ManagedPlugins/obj
+

--- a/ManagedPlugins/ManagedPlugins.sln
+++ b/ManagedPlugins/ManagedPlugins.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30804.86
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ManagedPlugins", "ManagedPlugins\ManagedPlugins.csproj", "{3B14F8B4-952D-4928-9B04-1B7F89185205}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3B14F8B4-952D-4928-9B04-1B7F89185205}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B14F8B4-952D-4928-9B04-1B7F89185205}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B14F8B4-952D-4928-9B04-1B7F89185205}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B14F8B4-952D-4928-9B04-1B7F89185205}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B3BB5370-A2F2-47AE-9AEA-6279A3399484}
+	EndGlobalSection
+EndGlobal

--- a/ManagedPlugins/ManagedPlugins/ManagedPlugins.csproj
+++ b/ManagedPlugins/ManagedPlugins/ManagedPlugins.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Define.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="resources\" />
+  </ItemGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="&#xD;&#xA;REM ビルド後イベント実行&#xD;&#xA;REM ------------------------------------------------&#xD;&#xA;REM INIファイルで指定したファイルにdllを書き出す。&#xD;&#xA;REM ------------------------------------------------&#xD;&#xA;&#xD;&#xA;REM デバッグ出力フラグ &quot;true:!=0&quot;&#xD;&#xA;set DEBUG_FLAG=0&#xD;&#xA;&#xD;&#xA;REM batファイル&#xD;&#xA;set INI_BAT=$(ProjDir)../../bat\GetIni.bat&#xD;&#xA;&#xD;&#xA;REM 読み込むiniファイル&#xD;&#xA;set READ_INI_PATH=$(ProjDir)resources\build.ini&#xD;&#xA;&#xD;&#xA;REM batが無ければ処理しない&#xD;&#xA;if not exist %25INI_BAT%25 (&#xD;&#xA;  echo バッチファイルが存在しない。&quot;%25INI_BAT%25&quot;&#xD;&#xA;  exit&#xD;&#xA;)&#xD;&#xA;&#xD;&#xA;REM iniが無ければ処理しない&#xD;&#xA;if not exist %25READ_INI_PATH%25 (&#xD;&#xA;  echo iniファイルが存在しない。&quot;%25READ_INI_PATH%25&quot;&#xD;&#xA;  exit&#xD;&#xA;)&#xD;&#xA;&#xD;&#xA;REM フォルダ内にある全ファイルに対して走らせるので遅延環境変数を使う&#xD;&#xA;setlocal enabledelayedexpansion&#xD;&#xA;&#xD;&#xA;for /f &quot;tokens=1 delims==&quot; %25%25k in (%25READ_INI_PATH%25) do (&#xD;&#xA;&#xD;&#xA;  set KEY=%25%25k&#xD;&#xA;  set FORMAT=!KEY:~0,1!!KEY:~-1,1!&#xD;&#xA;&#xD;&#xA;  if not %25DEBUG_FLAG%25==0 echo ↓読み込んでいる値↓&#xD;&#xA;  if not %25DEBUG_FLAG%25==0 echo キー:!KEY!&#xD;&#xA;  if not %25DEBUG_FLAG%25==0 echo フォーマット:!FORMAT!&#xD;&#xA;&#xD;&#xA;  if not &quot;!FORMAT!&quot;==&quot;[]&quot; (&#xD;&#xA;    call %25INI_BAT%25 :READ_INI_VAL &quot;OUTPUT&quot; !KEY! COPYPATH  %25READ_INI_PATH%25&#xD;&#xA;    if not %25DEBUG_FLAG%25==0 echo ファイルから読み取った値:!COPYPATH!&#xD;&#xA;    &#xD;&#xA;    REM コピー先のフォルダがあるか&#xD;&#xA;    if exist !COPYPATH! (&#xD;&#xA;      if not %25DEBUG_FLAG%25==0 echo コピー先のパス:&quot;!COPYPATH!&quot;&#xD;&#xA;      REM 出力ファイル(*.dll)をコピー&#xD;&#xA;      copy /y &quot;$(OutDir)$(TargetFileName)&quot; &quot;!COPYPATH!&quot;&#xD;&#xA;    ) else if !COPYPATH!==NULL ( &#xD;&#xA;      if not %25DEBUG_FLAG%25==0 echo 読み込みに失敗しました。&#xD;&#xA;    ) else (&#xD;&#xA;      if not %25DEBUG_FLAG%25==0 echo コピー先のフォルダがありませんでした。:&quot;!COPYPATH!&quot;&#xD;&#xA;    )&#xD;&#xA;    REM 見にくいので一行だけ空行を挟む&#xD;&#xA;    if not %25DEBUG_FLAG%25==0 echo.&#xD;&#xA;  )&#xD;&#xA;)&#xD;&#xA;REM 遅延環境変数を使うのはココで終わり&#xD;&#xA;endlocal" />
+  </Target>
+
+</Project>

--- a/ManagedPlugins/ManagedPlugins/resources/build.ini
+++ b/ManagedPlugins/ManagedPlugins/resources/build.ini
@@ -1,0 +1,4 @@
+;書き出し先のフォルダ
+;(ビルドイベントなので*.csprojからの相対パス)
+[OUTPUT]
+COPY_PATH1=..\..\Client\Assets\Plugins\ManagedPlugins

--- a/ManagedPlugins/ManagedPlugins/sources/Define.cs
+++ b/ManagedPlugins/ManagedPlugins/sources/Define.cs
@@ -1,0 +1,18 @@
+﻿namespace Yuki.ManagedPlugins
+{
+    /// <summary>
+    /// 定数宣言
+    /// </summary>
+    public class Define
+    {
+        /// <summary>
+        /// コンストラクタ隠蔽
+        /// </summary>
+        private Define() { }
+        public const int NOTHING_LAYER_VALUE = 0;
+        public const int EVERYTHING_LAYER_VALUE = ~0;
+        public const float MAX_ALPHA = 1.0f;
+        public const float MIN_ALPHA = 0.0f;
+        public const string ANDROID_LOCAL_HEADER = "file:///";
+    }
+}


### PR DESCRIPTION
## 概要
`ManagedPlugins`の実装。

## 実装
現状使いそうな定数宣言だけ。
プロジェクトのビルドイベントにClientのPluginsフォルダを書き出し先に指定したコピー処理を流しているためプロジェクトをビルドすればdllが自動的にCLのPluginsフォルダに書き出される。
設定は`build.ini`参照。
(キーと値:書き出し先のパスを追加すれば追加で書き出してくれる。)

※UnityEngine及びUnityEditorのパスを通していないため、必要に応じてパスを通す。