### PR TITLE
【Environment】C++NativePlugins追加

### DIFF
--- a/Client/Assets/Plugins/NativePlugins.meta
+++ b/Client/Assets/Plugins/NativePlugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e12d6bdcec302324a882a81d490c38b0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/NativePlugins/.gitignore
+++ b/NativePlugins/.gitignore
@@ -1,0 +1,7 @@
+# ExecutionProject
+ExecutionProject/bin/
+ExecutionProject/obj/
+
+# ExternalDynamicLinkLibrary
+ExternalDynamicLinkLibrary/bin/
+ExternalDynamicLinkLibrary/obj/

--- a/NativePlugins/BuildEventSubRoutine.bat
+++ b/NativePlugins/BuildEventSubRoutine.bat
@@ -1,0 +1,137 @@
+@echo off
+REM ====================================================================================
+REM VC++のビルドイベントに仕込んだら下記エラーが出た。
+REM > MSB3073:VCEndはコード 123 で終了しました
+REM どうやら全角文字列を使っているフォルダが引っかかっているみたいなのだが、
+REM そんなの作っていない。
+REM おそらく、「外部依存関係」「ソースファイル」「ヘッダーファイル」「リソースファイル」
+REM この辺が引っかかっているのかもしれない。
+REM
+REM 回避策として実処理をバッチにして呼び出す形を取る。
+REM ※
+REM 出力ファイル(*.dll)のみのコピーなのでフォルダ毎コピーしたければ引数指定している
+REM ビルドイベントを下記のように変更する。
+REM ↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓
+REM 【ExternalDynamicLinkLibrary ビルド後のイベント】
+REM ```
+REM 変更前
+REM set COPY_TARGET=$(TargetDir)$(TargetFileName)
+REM 変更後
+REM set COPY_TARGET=$(TargetDir)
+REM ```
+REM ====================================================================================
+REM 遅延環境変数処理
+setlocal enabledelayedexpansion
+
+REM デバッグフラグ"true:!=0"
+set DEBUG_FLAG=0
+
+REM コピー対象のファイル/フォルダ : *.dllもしくは$(OutDir)を引数に取る
+set COPY_TARGET=%~1
+set COPY_TARGET_EXTENSION=%~x1
+
+REM INIファイルのディレクトリ : BuildEventで$(SolutionDir)を引数に取る
+set INI_DIR=%~2
+
+REM コピー対象のファイルが存在しなければ処理できない
+if not exist "!COPY_TARGET!" (
+  echo Copy target is not found: "!COPY_TARGET!"
+  exit /b
+)
+
+REM 空ならカレントディレクトリ
+if "!INI_DIR!"=="" ( 
+  set INI_DIR="./"
+  echo set current directory.
+)
+
+REM ディレクトリがない
+if not exist "!INI_DIR!" (
+  echo Directory is not exist: "!INI_DIR!"
+  exit /b
+)
+
+REM ソリューションがあるディレクトリからサブディレクトリ含めiniファイルを検索。
+for /r %INI_DIR% %%x in (*.ini) do (
+  
+  REM 読み込んだパスの出力
+  if not %DEBUG_FLAG%==0 echo READ_PATH:"%%x"
+
+  REM コピー処理
+  call :SUB_ROUTINE %%x
+)
+
+exit /b
+
+REM .ini 特定のセクションを読み込む
+:SUB_ROUTINE
+
+REM .ini 解析バッチ
+REM ※GetIni.batまでの相対パスなのでパスを変えたら変更する必要がある
+REM (ビルドイベントから呼び出すので.vcxprojからの相対パス)
+set BAT_PATH=..\..\bat\GetIni.bat
+
+REM 読み込むセクション
+set TARGET_SECTION=CLONE
+
+REM 読み込んだセクション
+set SECTION=
+
+REM 読み込む.ini
+set READ_INI=%~1
+
+REM .ini 解析処理
+for /f "tokens=1 delims==" %%k in ( !READ_INI! ) do (
+  
+  REM 読み込んだキー
+  set KEY=%%k
+
+  REM 読み込んだ値がセクションかどうか判定する [*]
+  set FORMAT=!KEY:~0,1!!KEY:~-1,1!
+
+  REM セクションを更新
+  if "!FORMAT!"=="[]" set SECTION=!KEY!
+
+  REM デバッグ
+  if not %DEBUG_FLAG%==0 echo SECTION: "!SECTION!"
+  if not %DEBUG_FLAG%==0 echo KEY: "!KEY!"
+  if not %DEBUG_FLAG%==0 echo FORMAT: "!FORMAT!"
+
+  REM 指定のセクションなら
+  if "!SECTION!"=="[!TARGET_SECTION!]" if not "!FORMAT!"=="[]" (
+
+    REM .ini 解析
+    call %BAT_PATH% :READ_INI_VAL "!TARGET_SECTION!" "!KEY!" VALUE %READ_INI%
+
+    REM 読み込んだディレクトリが存在してたら実行
+    if exist "!VALUE!" (
+
+      REM ファイル(フォルダ)コピー
+      
+      REM ディレクトリの場合
+      if "!COPY_TARGET_EXTENSION!"=="" (
+
+        REM 文字列末尾が'\'はコピー対象でなくなってしまうためパスを書き換える
+        set COPY_TARGET_LAST_CHARA=!COPY_TARGET:~-1,1!
+        if "!COPY_TARGET_LAST_CHARA!"=="\" (
+          set COPY_TARGET=!COPY_TARGET:~0,-1!
+        )
+        echo Copy target is directory.
+        xcopy "!COPY_TARGET!" "!VALUE!" /y
+      REM ファイルの場合
+      ) else (
+        echo Copy target is file: "!COPY_TARGET!"
+        copy /y "!COPY_TARGET!" "!VALUE!"
+      )
+    REM ディレクトリが無かった場合
+    ) else (
+      echo Copy target is not found: "!VALUE!"
+    )
+  )
+  REM 改行
+  if not %DEBUG_FLAG%==0 echo.
+)
+exit /b
+
+REM 遅延環境変数終了
+endlocal

--- a/NativePlugins/ExecutionProject/ExecutionProject.vcxproj
+++ b/NativePlugins/ExecutionProject/ExecutionProject.vcxproj
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="include\EntryPoint\EntryPoint.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{69a0ebe8-ca35-4ae9-80ed-9a794e673b3e}</ProjectGuid>
+    <RootNamespace>ExecutionProject</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IntDir>obj\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>bin\$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>bin\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>obj\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IntDir>obj\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>bin\$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>bin\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>obj\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>.\ExternalDynamicLinkLibrary\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\bin\$(Platform)\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ExternalDynamicLinkLibrary.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PreBuildEvent>
+      <Command>REM 依存するdll
+set EXTERNAL_DLL_PATH=$(SolutionDir)ExternalDynamicLinkLibrary\\bin\$(Platform)\$(Configuration)\ExternalDynamicLinkLibrary.dll
+
+REM 書き出し先にファイルコピー
+copy /y %EXTERNAL_DLL_PATH% $(OutDir)</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>ExternalDynamicLinkLibrary.dllを書き出し先にコピーする。</Message>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>.\ExternalDynamicLinkLibrary\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\bin\$(Platform)\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ExternalDynamicLinkLibrary.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PreBuildEvent>
+      <Command>REM 依存するdll
+set EXTERNAL_DLL_PATH=$(SolutionDir)ExternalDynamicLinkLibrary\\bin\$(Platform)\$(Configuration)\ExternalDynamicLinkLibrary.dll
+
+REM 書き出し先にファイルコピー
+copy /y %EXTERNAL_DLL_PATH% $(OutDir)</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>ExternalDynamicLinkLibrary.dllを書き出し先にコピーする。</Message>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>.\ExternalDynamicLinkLibrary\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\bin\$(Platform)\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ExternalDynamicLinkLibrary.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PreBuildEvent>
+      <Command>REM 依存するdll
+set EXTERNAL_DLL_PATH=$(SolutionDir)ExternalDynamicLinkLibrary\\bin\$(Platform)\$(Configuration)\ExternalDynamicLinkLibrary.dll
+
+REM 書き出し先にファイルコピー
+copy /y %EXTERNAL_DLL_PATH% $(OutDir)</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>ExternalDynamicLinkLibrary.dllを書き出し先にコピーする。</Message>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>.\ExternalDynamicLinkLibrary\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\bin\$(Platform)\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ExternalDynamicLinkLibrary.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PreBuildEvent>
+      <Command>REM 依存するdll
+set EXTERNAL_DLL_PATH=$(SolutionDir)ExternalDynamicLinkLibrary\\bin\$(Platform)\$(Configuration)\ExternalDynamicLinkLibrary.dll
+
+REM 書き出し先にファイルコピー
+copy /y %EXTERNAL_DLL_PATH% $(OutDir)</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>ExternalDynamicLinkLibrary.dllを書き出し先にコピーする。</Message>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/NativePlugins/ExecutionProject/ExecutionProject.vcxproj.filters
+++ b/NativePlugins/ExecutionProject/ExecutionProject.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="ソース ファイル">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="ヘッダー ファイル">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="リソース ファイル">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="include\EntryPoint\EntryPoint.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/NativePlugins/ExecutionProject/ExecutionProject.vcxproj.user
+++ b/NativePlugins/ExecutionProject/ExecutionProject.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/NativePlugins/ExecutionProject/include/EntryPoint/EntryPoint.cpp
+++ b/NativePlugins/ExecutionProject/include/EntryPoint/EntryPoint.cpp
@@ -1,0 +1,29 @@
+/*!
+	@file			EntryPoint.cpp
+	@brief		ExternalDynamicLinkLibraryプロジェクトで生成した*.dllの実行テスト環境。主にエラーチェックなど。
+	@detail		予めプロジェクトにパスを通したのとビルドイベントで依存ファイルの"ExternalDynamicLinkLibrary"をコピーする処理を入れてある。
+					※依存プロジェクトが増えたり、名前を変更した場合はパスの通し直しとビルドイベントの編集も必要になる
+	@todo		テスト用のこのプロジェクト以外は基本的にdllのプロジェクトになるはずなのでビルド時に依存関係を追加してくれる機能(機構)が欲しい。
+					例:XInput.dllのパスを通した別のプロジェクトを用意したら面倒なパス追加処理とビルドイベント登録無しで勝手にやってくれるのがベスト。
+*/
+#pragma once
+#include <iostream>
+#include "../../../ExternalDynamicLinkLibrary/include/Sample/Sample.hpp"
+
+#define SUCCESS 0
+
+using namespace std;
+
+/*!
+	@brief エントリーポイント
+	@note  CLIから実行した際に引数を渡せるように用意だけしとく。
+	@param[in]:引数の個数
+	@param[in]:引数文字列
+	@return:正常終了=０ , 異常終了=!０(TODO:エラーコードを設け、クラス分けしたい)
+*/
+int main(int argNum, const char* argments) 
+{
+	//とりあえず空
+	system("pause");
+	return SUCCESS;
+}

--- a/NativePlugins/ExternalDynamicLinkLibrary/ExternalDynamicLinkLibrary.vcxproj
+++ b/NativePlugins/ExternalDynamicLinkLibrary/ExternalDynamicLinkLibrary.vcxproj
@@ -1,0 +1,290 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="include\Sample\Sample.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="include\Sample\Sample.hpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{fa60ae1d-599b-4fe8-ad51-76e910e62630}</ProjectGuid>
+    <RootNamespace>ExternalDynamicLinkLibrary</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>bin\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>obj\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>bin\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>obj\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>bin\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>obj\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>bin\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>obj\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>
+      </Message>
+    </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>REM 遅延環境変数処理
+setlocal enabledelayedexpansion
+
+REM バッチパス
+set BAT_PATH=$(SolutionDir)BuildEventSubRoutine.bat
+
+REM 探索ディレクトリ
+set READ_DIR=$(SolutionDir)
+
+REM 対象ファイル
+set COPY_TARGET=$(TargetDir)$(TargetFileName)
+
+REM =================================================================================
+REM todo:出力ファイルにこのプロジェクトの出力しか考慮されてないので使用している他のdllは対象外(例えばXInput.dllとか)
+REM          ネイティブプラグインだから考えてなかったけど、依存関係が生まれるようなら依存ライブラリも全部コピーするようにfixしたほうがいいかも
+REM =================================================================================
+
+REM 呼び出し
+call "!BAT_PATH!" "!COPY_TARGET!" "!READ_DIR!"
+
+REM 遅延環境変数終了
+endlocal</Command>
+      <Message>*.iniを読み込んで出力ファイルをコピーする</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>
+      </Message>
+    </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>REM 遅延環境変数処理
+setlocal enabledelayedexpansion
+
+REM バッチパス
+set BAT_PATH=$(SolutionDir)BuildEventSubRoutine.bat
+
+REM 探索ディレクトリ
+set READ_DIR=$(SolutionDir)
+
+REM 対象ファイル
+set COPY_TARGET=$(TargetDir)$(TargetFileName)
+
+REM =================================================================================
+REM todo:出力ファイルにこのプロジェクトの出力しか考慮されてないので使用している他のdllは対象外(例えばXInput.dllとか)
+REM          ネイティブプラグインだから考えてなかったけど、依存関係が生まれるようなら依存ライブラリも全部コピーするようにfixしたほうがいいかも
+REM =================================================================================
+
+REM 呼び出し
+call "!BAT_PATH!" "!COPY_TARGET!" "!READ_DIR!"
+
+REM 遅延環境変数終了
+endlocal</Command>
+      <Message>*.iniを読み込んで出力ファイルをコピーする</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>
+      </Message>
+    </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>REM 遅延環境変数処理
+setlocal enabledelayedexpansion
+
+REM バッチパス
+set BAT_PATH=$(SolutionDir)BuildEventSubRoutine.bat
+
+REM 探索ディレクトリ
+set READ_DIR=$(SolutionDir)
+
+REM 対象ファイル
+set COPY_TARGET=$(TargetDir)$(TargetFileName)
+
+REM =================================================================================
+REM todo:出力ファイルにこのプロジェクトの出力しか考慮されてないので使用している他のdllは対象外(例えばXInput.dllとか)
+REM          ネイティブプラグインだから考えてなかったけど、依存関係が生まれるようなら依存ライブラリも全部コピーするようにfixしたほうがいいかも
+REM =================================================================================
+
+REM 呼び出し
+call "!BAT_PATH!" "!COPY_TARGET!" "!READ_DIR!"
+
+REM 遅延環境変数終了
+endlocal</Command>
+      <Message>*.iniを読み込んで出力ファイルをコピーする</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>
+      </Message>
+    </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>REM 遅延環境変数処理
+setlocal enabledelayedexpansion
+
+REM バッチパス
+set BAT_PATH=$(SolutionDir)BuildEventSubRoutine.bat
+
+REM 探索ディレクトリ
+set READ_DIR=$(SolutionDir)
+
+REM 対象ファイル
+set COPY_TARGET=$(TargetDir)$(TargetFileName)
+
+REM =================================================================================
+REM todo:出力ファイルにこのプロジェクトの出力しか考慮されてないので使用している他のdllは対象外(例えばXInput.dllとか)
+REM          ネイティブプラグインだから考えてなかったけど、依存関係が生まれるようなら依存ライブラリも全部コピーするようにfixしたほうがいいかも
+REM =================================================================================
+
+REM 呼び出し
+call "!BAT_PATH!" "!COPY_TARGET!" "!READ_DIR!"
+
+REM 遅延環境変数終了
+endlocal</Command>
+      <Message>*.iniを読み込んで出力ファイルをコピーする</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/NativePlugins/ExternalDynamicLinkLibrary/ExternalDynamicLinkLibrary.vcxproj.filters
+++ b/NativePlugins/ExternalDynamicLinkLibrary/ExternalDynamicLinkLibrary.vcxproj.filters
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="ソース ファイル">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="ヘッダー ファイル">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="リソース ファイル">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="include\Sample\Sample.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="include\Sample\Sample.hpp">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/NativePlugins/ExternalDynamicLinkLibrary/ExternalDynamicLinkLibrary.vcxproj.user
+++ b/NativePlugins/ExternalDynamicLinkLibrary/ExternalDynamicLinkLibrary.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/NativePlugins/ExternalDynamicLinkLibrary/include/Sample/Sample.cpp
+++ b/NativePlugins/ExternalDynamicLinkLibrary/include/Sample/Sample.cpp
@@ -1,0 +1,31 @@
+//以下過去の遺物のコピペ:https://github.com/YuukiReiya/Template-UnityProject/blob/Develop/ColorScheme/UnityDLLforCPP/UnityDLLforCPP/Sample.cpp
+
+#include "Sample.hpp"
+#include <iostream>
+using namespace std;
+
+DLL_EXPORT int UNITY_API Add(int a, int b)
+{
+	return a + b;
+}
+
+DLL_EXPORT int UNITY_API AddPtr(int* a, int b)
+{
+	*a += b;
+	return *a;
+}
+
+DLL_EXPORT int* UNITY_API AddArray(int* ptr, size_t size, int add)
+{
+	for (size_t i = 0; i < size; ++i)
+	{
+		ptr[i] += add;
+	}
+	return ptr;
+}
+
+DLL_EXPORT int UNITY_API HotReloadTest()
+{
+	//	UnityEditor起動中にビルドしてDLLがリロードされれば返り値を変更した場合に取得できる値が変わる
+	return 10;
+}

--- a/NativePlugins/ExternalDynamicLinkLibrary/include/Sample/Sample.hpp
+++ b/NativePlugins/ExternalDynamicLinkLibrary/include/Sample/Sample.hpp
@@ -1,0 +1,26 @@
+//以下過去の遺物のコピペ:https://github.com/YuukiReiya/Template-UnityProject/blob/Develop/ColorScheme/UnityDLLforCPP/UnityDLLforCPP/Sample.hpp
+
+//C言語の関数として認識させることでネームマングリングを回避
+//※C++をCにラップして呼び出しているから実質"DLLforC"ということに注意!
+//ポインタの扱い:https://qiita.com/RyukiTANAKA96/items/000b11330c31435fcfae
+//前提知識:https://www.wagavulin.jp/entry/2017/02/09/215036
+//参考1:https://qiita.com/tan-y/items/64711b244cf294d6bb9d
+#pragma once
+#include <iostream>
+#define DLL_EXPORT  extern "C" __declspec(dllexport)
+#define UNITY_API __stdcall
+//	Unity上でPtrの呼び出しがどのようにされるか検証するために下記サンプルを用意
+
+//	値渡し
+DLL_EXPORT int UNITY_API Add(int, int);
+
+//	引数に参照渡し
+DLL_EXPORT int UNITY_API AddPtr(int*, int);
+
+//	配列全体に値を加算する
+DLL_EXPORT int* UNITY_API AddArray(int*, size_t, int);
+
+DLL_EXPORT int UNITY_API HotReloadTest();
+
+template<typename T, std::size_t N>
+static inline std::size_t GetArraySize(const T(&)[N]) { return N; }

--- a/NativePlugins/NativePlugins.sln
+++ b/NativePlugins/NativePlugins.sln
@@ -1,0 +1,44 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30804.86
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ExecutionProject", "ExecutionProject\ExecutionProject.vcxproj", "{69A0EBE8-CA35-4AE9-80ED-9A794E673B3E}"
+	ProjectSection(ProjectDependencies) = postProject
+		{FA60AE1D-599B-4FE8-AD51-76E910E62630} = {FA60AE1D-599B-4FE8-AD51-76E910E62630}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ExternalDynamicLinkLibrary", "ExternalDynamicLinkLibrary\ExternalDynamicLinkLibrary.vcxproj", "{FA60AE1D-599B-4FE8-AD51-76E910E62630}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{69A0EBE8-CA35-4AE9-80ED-9A794E673B3E}.Debug|x64.ActiveCfg = Debug|x64
+		{69A0EBE8-CA35-4AE9-80ED-9A794E673B3E}.Debug|x64.Build.0 = Debug|x64
+		{69A0EBE8-CA35-4AE9-80ED-9A794E673B3E}.Debug|x86.ActiveCfg = Debug|Win32
+		{69A0EBE8-CA35-4AE9-80ED-9A794E673B3E}.Debug|x86.Build.0 = Debug|Win32
+		{69A0EBE8-CA35-4AE9-80ED-9A794E673B3E}.Release|x64.ActiveCfg = Release|x64
+		{69A0EBE8-CA35-4AE9-80ED-9A794E673B3E}.Release|x64.Build.0 = Release|x64
+		{69A0EBE8-CA35-4AE9-80ED-9A794E673B3E}.Release|x86.ActiveCfg = Release|Win32
+		{69A0EBE8-CA35-4AE9-80ED-9A794E673B3E}.Release|x86.Build.0 = Release|Win32
+		{FA60AE1D-599B-4FE8-AD51-76E910E62630}.Debug|x64.ActiveCfg = Debug|x64
+		{FA60AE1D-599B-4FE8-AD51-76E910E62630}.Debug|x64.Build.0 = Debug|x64
+		{FA60AE1D-599B-4FE8-AD51-76E910E62630}.Debug|x86.ActiveCfg = Debug|Win32
+		{FA60AE1D-599B-4FE8-AD51-76E910E62630}.Debug|x86.Build.0 = Debug|Win32
+		{FA60AE1D-599B-4FE8-AD51-76E910E62630}.Release|x64.ActiveCfg = Release|x64
+		{FA60AE1D-599B-4FE8-AD51-76E910E62630}.Release|x64.Build.0 = Release|x64
+		{FA60AE1D-599B-4FE8-AD51-76E910E62630}.Release|x86.ActiveCfg = Release|Win32
+		{FA60AE1D-599B-4FE8-AD51-76E910E62630}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EDDAFEDE-C64A-4197-BA6C-E336654237E9}
+	EndGlobalSection
+EndGlobal

--- a/NativePlugins/buildevent.ini
+++ b/NativePlugins/buildevent.ini
@@ -1,0 +1,4 @@
+;複製先 (相対パス指定なので注意)
+[CLONE]
+UNITY_CLIENT=..\..\Client\Assets\Plugins\NativePlugins\
+;NATIVE_SERVER=..\..\Server\Server\lib


### PR DESCRIPTION
## 概要
`NativePlugins`の実装。

## 実装

**ExternalDynamicLinkLibrary**
C++実装の`DLL`プロジェクト。
ビルド(後)イベントに`buildevent.ini`で指定したフォルダに書き出す。
※とりあえずUnityに合わせているのでClientへの書き出しだけ。

**ExecutionProject**
上記`dll`の動作確認用のプロジェクト。
ビルド(前)イベントで`ExternalDynamicLinkLibrary`のdllをbinに書き出してる。