### PR TITLE
 【bugfix】 チャットのタスクを排他制御

### DIFF
--- a/Client/Assets/Scripts/ClientSample.cs
+++ b/Client/Assets/Scripts/ClientSample.cs
@@ -22,7 +22,6 @@ namespace Sample
 
         Task duplexChatReciveTask = null;
         uint cnt = 0;
-        bool isRun = false;
         public string IPAddress { get; set; } = "127.0.0.1";
         public int Port { get; set; } = 1122;
 
@@ -103,7 +102,7 @@ namespace Sample
                         await call.ResponseHeadersAsync;
                         //call.ResponseHeadersAsync.IsCompleted
                     });
-                    //if (isRun) return;
+
                     //送信
                     int i = 0;
                     while (i < ChatRequests.Count)
@@ -118,7 +117,7 @@ namespace Sample
                     await call.RequestStream.CompleteAsync();
                     await duplexChatReciveTask;
                     //receiveTask.Dispose();
-                    
+
                     Debug.Log("チャット終了");
                 }
 

--- a/Server/Server/sources/Model/Chat/ChatModel.protocol.cs
+++ b/Server/Server/sources/Model/Chat/ChatModel.protocol.cs
@@ -3,6 +3,7 @@ using Grpc.Core;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Server.gRPC;
 using Chat;
@@ -18,6 +19,12 @@ namespace Chat
 partial class BidirectionalStreamingImpl : BidirectionalStreaming.BidirectionalStreamingBase
 {
     /// <summary>
+    /// 排他制御用セマフォ
+    /// Task(async,await)で使うため'SemaphoreSlim'を起用している
+    /// /// </summary>
+    private static SemaphoreSlim semaphore = new SemaphoreSlim(1, 1);
+
+    /// <summary>
     /// 双方向チャット通信
     /// </summary>
     /// <param name="requestStream"></param>
@@ -26,39 +33,14 @@ partial class BidirectionalStreamingImpl : BidirectionalStreaming.BidirectionalS
     /// <returns></returns>
     public override async Task DuplexChat(IAsyncStreamReader<DuplexChatSend> requestStream, IServerStreamWriter<DuplexChatReceive> responseStream, ServerCallContext context)
     {
+        // ロック取れるまで待つ
+        await semaphore.WaitAsync();
+
         try
         {
             while (await requestStream.MoveNext())
             {
                 var current = requestStream.Current;
-
-                // 許容メッセージ数を超過したら古いものから消していく。
-                //if(ChatModel.Instance.Messages.Count>=ChatModel.SaveMessagesCount)
-                //{
-                //    ChatModel.Instance.Messages.Remove(ChatModel.Instance.Messages.First());
-                //}
-                //ChatModel.Instance.Messages.Add(new ChatModel.Info(current.UserID, current.Message));
-                //for (int i = 0; i < ChatModel.Instance.Messages.Count; ++i)
-                //{
-                //    //var message = ChatModel.Instance.Messages[i];
-                //    var message = ChatModel.Instance.Messages.ElementAt(i);
-                //    Console.WriteLine($"{message.UserID}:{message.Message}");
-                //    await responseStream.WriteAsync(new DuplexChatReceive { UserID = message.UserID, Message = message.Message });
-                //}
-
-                /*
-                例外:System.InvalidOperationException
-                Already finished.
-                at Grpc.Core.Internal.AsyncCallServer`2.CheckSendAllowedOrEarlyResult()
-                at Grpc.Core.Internal.AsyncCallBase`2.SendMessageInternalAsync(TWrite msg, WriteFlags writeFlags)
-                at BidirectionalStreamingImpl.DuplexChat(IAsyncStreamReader`1 requestStream, IServerStreamWriter`1 responseStream, ServerCallContext context) 
-                in ChatModel.protocol.cs:line 60
-
-                例外:System.IO.IOException
-                Error sending from server.
-                at BidirectionalStreamingImpl.DuplexChat(IAsyncStreamReader`1 requestStream, IServerStreamWriter`1 responseStream, ServerCallContext context)
-                in ChatModel.protocol.cs:line 60
-                */
 
                 // 許容メッセージ数を超過したら古いものから消していく。
                 if (ChatModel.Instance.Messages.Count >= ChatModel.MessageCapacity)
@@ -80,6 +62,11 @@ partial class BidirectionalStreamingImpl : BidirectionalStreaming.BidirectionalS
         {
             Console.WriteLine($"例外:{e.GetType()}\n{e.Message}\n{e.StackTrace}");
             throw;
+        }
+        finally
+        {
+            // ロックの解除
+            semaphore.Release();
         }
     }
 }

--- a/Server/Server/sources/Thread/AbstractThread.cs
+++ b/Server/Server/sources/Thread/AbstractThread.cs
@@ -29,7 +29,7 @@ namespace Framework
         /// <summary>
         /// スレッドIDのCLI上出力フラグ
         /// </summary>
-        protected bool IsDisplayThreadID { get; set; } = true;
+        protected bool IsDisplayThreadID { get; set; } = false;
 #endif
 
         public AbstractThread(uint fps)


### PR DESCRIPTION
## [問題](#10)
#10 

## 原因

排他制御されていなかったのが原因っぽい。
gRPCはCLからリクエストが飛んでSVでキャッチする際に`Task`(別スレッド)で処理しているため、
ストリーム(`response`)に書き込んでいる際に再度リクエストを飛ばせる。
ストリーム(`response`)書き込み中にリクエストが飛ぶと同じCL相手のストリーム(`response`)を再度編集するからおかしくなっているのか？
ちょっとよくわからない。

## 対応

とりあえず`Task`にセマフォを仕込んで排他制御することで対応。
リクエスト連打してもエラーが出なくなったことを確認。

※リファクタリングと不要コメント削除も入っている。

## TODO

`async,await`でも使える`lock`処理が`SemaphoreSlim`だったから何も考えず、使っているけど必要に応じて変える。
排他制御周り勉強しよう…。