### PR TITLE
【Develop】Editor拡張用のスクリプトを追加

### DIFF
--- a/Client/Assets/Editor/Expansion.meta
+++ b/Client/Assets/Editor/Expansion.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f9134308cee3f45438c16325541a778f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Editor/Expansion/EditorApplication.meta
+++ b/Client/Assets/Editor/Expansion/EditorApplication.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 53c78982703aa7e43a6c6a1ee591d48c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Editor/Expansion/EditorApplication/EditorApplicationExpansion.cs
+++ b/Client/Assets/Editor/Expansion/EditorApplication/EditorApplicationExpansion.cs
@@ -1,0 +1,38 @@
+﻿//参考:https://baba-s.hatenablog.com/entry/2017/12/04/090000#Unity-%E3%82%A8%E3%83%87%E3%82%A3%E3%82%BF%E4%B8%8A%E3%81%A7%E4%BD%95%E3%81%8B%E6%93%8D%E4%BD%9C%E3%81%95%E3%82%8C%E3%81%9F%E6%99%82
+//InitializeOnLoad:https://docs.unity3d.com/ja/2019.4/Manual/RunningEditorCodeOnLaunch.html
+using System.Reflection;
+using System.Collections.Generic;
+using System.Diagnostics;
+using UnityEditor;
+
+#if UNITY_EDITOR
+[InitializeOnLoad]
+public static class EditorApplicationExpansion
+{
+    private const BindingFlags c_BindingFlags = BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic;
+    private static readonly FieldInfo m_info = null;
+
+    static EditorApplicationExpansion()
+    {
+        UnityEngine.Debug.Log("<color=green>InitializeOnLoad</color>:EditorApplicationExpansion");
+        m_info = typeof(EditorApplication).GetField("OnValidate", c_BindingFlags);
+    }
+
+    public static EditorApplication.CallbackFunction OnValidate
+    {
+        get => m_info.GetValue(null) as EditorApplication.CallbackFunction;
+        set
+        {
+            var callback = m_info.GetValue(null) as EditorApplication.CallbackFunction;
+            callback += value;
+            m_info.SetValue(null, callback);
+        }
+    }
+
+    public static EditorApplication.CallbackFunction OnUpdate
+    {
+        get => EditorApplication.update;
+        set => EditorApplication.update += value;
+    }
+}
+#endif

--- a/Client/Assets/Editor/Expansion/EditorApplication/EditorApplicationExpansion.cs.meta
+++ b/Client/Assets/Editor/Expansion/EditorApplication/EditorApplicationExpansion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8ffee56c18e5804d806a86dacb1fc06
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Editor/Expansion/SerializedProperty.meta
+++ b/Client/Assets/Editor/Expansion/SerializedProperty.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9256932249854a64286a442756790f53
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Editor/Expansion/SerializedProperty/SerializedPropertyExpansion.cs
+++ b/Client/Assets/Editor/Expansion/SerializedProperty/SerializedPropertyExpansion.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+
+public static class SerializedPropertyExpansion
+{
+    /// <summary>
+    /// MonoBehaviour継承クラスか.
+    /// </summary>
+    /// <param name="property"></param>
+    /// <returns></returns>
+    public static bool IsMonoBehaviour(this SerializedProperty property)
+    {
+        return property.serializedObject.targetObject.GetType().IsSubclassOf(typeof(UnityEngine.MonoBehaviour));
+    }
+
+}

--- a/Client/Assets/Editor/Expansion/SerializedProperty/SerializedPropertyExpansion.cs.meta
+++ b/Client/Assets/Editor/Expansion/SerializedProperty/SerializedPropertyExpansion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 901903911547bd1498134ea077ec1508
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要

Editorで変更を加えた際に通知出来るように簡単に設定できるようにコールバックを設けたクラスを用意。
Editor拡張用にSerializedPropertyがMonoBehaviour継承か判定するための拡張メソッド用意。