### PR TITLE
【Develop】discards(_)の使い方が適していなかった部分の変数名を修正

### DIFF
--- a/Client/Assets/Scripts/ADV/AdventureTextWindow.cs
+++ b/Client/Assets/Scripts/ADV/AdventureTextWindow.cs
@@ -75,7 +75,7 @@ namespace uGUI.ADV
         void Start()
         {
             var list = new List<AdventureTextData>();
-            testData.ForEach(_ => list.Add(new AdventureTextData { Text = _, ID = 0, ActorName = "tester" })) ;
+            testData.ForEach(data => list.Add(new AdventureTextData { Text = data, ID = 0, ActorName = "tester" })) ;
             Setup(list);
             SetNextText();
             m_message.text = string.Empty;

--- a/Client/Assets/Scripts/Chat/UIChatWindow.cs
+++ b/Client/Assets/Scripts/Chat/UIChatWindow.cs
@@ -40,18 +40,18 @@ namespace uGUI.Chat
         public void OnReceiveChat(DuplexChatReceive receive)
         {
             // 許容数を超えたら古いものからプールに帰し再利用する
-            if (cellPoolList.Pool.Count(_ => !cellPoolList.IsGetPool(_)/* プール判定条件の偽 */) > ChatModel.Instance.MessageCapacity)
+            if (cellPoolList.Pool.Count(cell => !cellPoolList.IsGetPool(cell)/* プール判定条件の偽 */) > ChatModel.Instance.MessageCapacity)
             {
                 var target = cellPoolList.Pool.
-                    Where(_ => !cellPoolList.IsGetPool(_)).//プール対象じゃない ＝ 現在利用中
-                    OrderBy(_ => _.Receive.Hash).             //追加順
+                    Where(cell => !cellPoolList.IsGetPool(cell)).//プール対象じゃない ＝ 現在利用中
+                    OrderBy(cell => cell.Receive.Hash).             //追加順
                     FirstOrDefault();                                     //最初の要素
 
                 // プールに戻す
                 RecycleCell(target);
             }
-            var cell = cellPoolList.Get();
-            cell.Setup(receive);
+            var instance = cellPoolList.Get();
+            instance.Setup(receive);
         }
 
         private void RecycleCell(UIChatCell recycleCell)

--- a/Client/Assets/Scripts/Common/Reflection/ScriptableHelper.cs
+++ b/Client/Assets/Scripts/Common/Reflection/ScriptableHelper.cs
@@ -22,7 +22,7 @@ namespace Helper
         {
             var method = typeof(T).GetMethod(methodName, bindFlag,
                 null,
-                arguments.Select(_ => _.GetType()).ToArray(),
+                arguments.Select(arg => arg.GetType()).ToArray(),
                 null);
             if (method == null)
             {
@@ -57,7 +57,7 @@ namespace Helper
 
         public static void CallStaticMethod<T>(string methodName, params object[] arguments)
         {
-            var method = typeof(T).GetMethod(methodName, c_StaticMethodBindingFlag, null, arguments.Select(_ => _.GetType()).ToArray(), null);
+            var method = typeof(T).GetMethod(methodName, c_StaticMethodBindingFlag, null, arguments.Select(arg => arg.GetType()).ToArray(), null);
             if (method == null)
             {
                 Debug.LogError($"Not found method. : \"{typeof(T)}.{methodName}\"({string.Join(",", arguments)})");

--- a/Client/Assets/Scripts/Model/Chat/ChatModel.cs
+++ b/Client/Assets/Scripts/Model/Chat/ChatModel.cs
@@ -81,7 +81,7 @@ namespace Model.Chat
         public void S2C_Receive_Duplex_Chat(DuplexChatReceive receive)
         {
             // 同じデータが重複して登録されることを防ぐために選別
-            if (!ReceivedMessages.Any(_ => _.Hash == receive.Hash))
+            if (!ReceivedMessages.Any(registered => registered.Hash == receive.Hash))
             {
                 // 受け取り処理
                 OnReciveChatMessage?.Invoke(receive);


### PR DESCRIPTION
## 概要

https://blog.xin9le.net/entry/2017/05/28/020129
C#7.0以降
* out 引数
* 型分解 (= Deconstruction)
* 型スイッチ

上記が対応しているやつらしい。

## 対応

間違ったdiscard(_)宣言をしているやつ修正。

Post,Switchは使い方に誤りなさそうだったので修正なし。