### PR TITLE
【Bugfix】 AssetPostprocessorでインポートしたスクリプトのエンコード処理を行うと無限ループするバグ修正

### DIFF
--- a/Client/Assets/Editor/AssetPostprocessor/AssetPostprocessorImpl.cs
+++ b/Client/Assets/Editor/AssetPostprocessor/AssetPostprocessorImpl.cs
@@ -19,7 +19,7 @@ namespace Editor.Expansion
         /// </summary>
         private static IAssetPostprocess[] ImportPostprocesses =
         {
-            //new ScriptEncoder(),
+            new ScriptEncoder(),
         };
 
         /// <summary>

--- a/Client/Assets/Editor/ScriptEncoder/ScriptEncoder.cs
+++ b/Client/Assets/Editor/ScriptEncoder/ScriptEncoder.cs
@@ -70,7 +70,7 @@ namespace Editor.Expansion
             if (enc != null)
             {
                 // BOM付きUTF-8なら変換は不要なのでリターンする
-                if (enc != Encoding.UTF8 && HaveBOM(bin)) return;
+                if (enc == Encoding.UTF8 && HaveBOM(bin)) return;
             }
             // エンコード形式がわからなかった.
             else


### PR DESCRIPTION
## 概要

* スクリプトのエンコード処理を入れると無限ループする。
* 先頭ヘッダに不要バイトが追加される。

## 原因・対応

一度変換したファイルはBOM付きのUTF-8のはずなので早期リターンして入らなくなるようにする。
というか条件式が間違ってた？