### PR TITLE
【Develop】非同期のインポート処理をアプリがCancellationToken対応

### DIFF
--- a/Client/Assets/Scripts/Masters/Table/Importer/CSVTableImporter.cs
+++ b/Client/Assets/Scripts/Masters/Table/Importer/CSVTableImporter.cs
@@ -18,6 +18,8 @@ namespace IO
         private List<string> columnNames = new List<string>();
         private TableBase csv;
 
+        public CSVTableImporter(CancellationTokenSource cts) : base(cts) { }
+
         void IDisposable.Dispose()
         {
             csv = null;

--- a/Client/Assets/Scripts/Masters/Table/Importer/TableImportFactory.cs
+++ b/Client/Assets/Scripts/Masters/Table/Importer/TableImportFactory.cs
@@ -1,4 +1,5 @@
-using System.IO;
+﻿using System.IO;
+using System.Threading;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -9,13 +10,13 @@ namespace Masters
 {
     public static class TableImportFactory
     {
-        public static TableImporter CreateTableImporter(string pathWithExtension)
+        public static TableImporter CreateTableImporter(string pathWithExtension, CancellationTokenSource cancellationTokenSource)
         {
             var ext = Path.GetExtension(pathWithExtension);
             return ext switch
             {
                 // .csv
-                CSVTable.Extension => new CSVTableImporter(),
+                CSVTable.Extension => new CSVTableImporter(cancellationTokenSource),
 
                 // default
                 _ => throw new System.Exception($"ImportException: Invalid extension. > { pathWithExtension }"),

--- a/Client/Assets/Scripts/Masters/Table/MasterData.cs
+++ b/Client/Assets/Scripts/Masters/Table/MasterData.cs
@@ -18,7 +18,7 @@ namespace Masters
     {
         #region 変数
         public static SynchronizationContext Context { get; private set; } = null;
-
+        private CancellationTokenSource cts = new CancellationTokenSource();
         private Task importTask = null;
         private Dictionary<string, TableImporter> tableImporterCacheDic = new Dictionary<string, TableImporter>();
         public Dictionary<uint, TableBase> TableDic { get; private set; } = new Dictionary<uint, TableBase>();
@@ -54,6 +54,11 @@ namespace Masters
             Import();
         }
 
+        private void OnApplicationQuit()
+        {
+            Debug.LogError("OnApplicationQuit");
+            cts.Cancel();
+        }
 #if UNITY_EDITOR
         [ContextMenu("Import Test")]
         private void TestImport()
@@ -124,7 +129,7 @@ namespace Masters
                 var extension = Path.GetExtension(current.PathWithExtension);
                 if (!tableImporterCacheDic.TryGetValue(extension, out importer))
                 {
-                    importer = TableImportFactory.CreateTableImporter(current.PathWithExtension);
+                    importer = TableImportFactory.CreateTableImporter(current.PathWithExtension, cts);
                     tableImporterCacheDic.Add(extension, importer);
                 }
                 Debug.Log($"{current.PathWithExtension} is import start.");

--- a/UnityEditor/global/81-C# Script-NewBehaviourScript.cs.sample.txt
+++ b/UnityEditor/global/81-C# Script-NewBehaviourScript.cs.sample.txt
@@ -1,0 +1,26 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+    #ROOTNAMESPACEBEGIN#
+public class #SCRIPTNAME# : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        #NOTRIM#
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        #NOTRIM#
+    }
+}
+#ROOTNAMESPACEEND#


### PR DESCRIPTION
## 概要

 ee46614:develop script生成のテンプレートファイル編集 
\> Editor内で新規にスクリプトを作った際のテンプレートファイルにTaskやLinqを追加。
```
C:\Program Files (x86)\Unity\Editor\Data\Resources\ScriptTemplates
※環境によってパスは変わるかも。

81-C# Script-NewBehaviourScript.cs.sample.txt
用意したファイルの`.sample`を部分を削除し、上記テンプレートファイルに置換。
```

047534c:develop 非同期インポート処理のキャンセル対応
\> `CancellationTokenSource`を利用したキャンセル処理の実装。
アプリケーションが止まった時にインポートを中断するようにした。
※プロファイラーにも非同期スレッドを表示するようにした。