### PR TITLE
【Fix】v3 調整

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,19 +6,19 @@
 #bat/
 
 # gRPC
-Client/Assets/Plugins/Google.Protobuf
-Client/Assets/Plugins/Google.Protobuf.meta
-Client/Assets/Plugins/Grpc.Core
-Client/Assets/Plugins/Grpc.Core.meta
-Client/Assets/Plugins/Grpc.Core.Api
-Client/Assets/Plugins/Grpc.Core.Api.meta
-Client/Assets/Plugins/System.Buffers
-Client/Assets/Plugins/System.Buffers.meta
-Client/Assets/Plugins/System.Memory
-Client/Assets/Plugins/System.Memory.meta
-Client/Assets/Plugins/System.Runtime.CompilerServices.Unsafe
-Client/Assets/Plugins/System.Runtime.CompilerServices.Unsafe.meta
-Client/Assets/Plugins/System.Runtime.CompilerServices.Unsafe.meta
+Client/Assets/Plugins/*/Google.Protobuf
+Client/Assets/Plugins/*/Google.Protobuf.meta
+Client/Assets/Plugins/*/Grpc.Core
+Client/Assets/Plugins/*/Grpc.Core.meta
+Client/Assets/Plugins/*/Grpc.Core.Api
+Client/Assets/Plugins/*/Grpc.Core.Api.meta
+Client/Assets/Plugins/*/System.Buffers
+Client/Assets/Plugins/*/System.Buffers.meta
+Client/Assets/Plugins/*/System.Memory
+Client/Assets/Plugins/*/System.Memory.meta
+Client/Assets/Plugins/*/System.Runtime.CompilerServices.Unsafe
+Client/Assets/Plugins/*/System.Runtime.CompilerServices.Unsafe.meta
+Client/Assets/Plugins/*/System.Runtime.CompilerServices.Unsafe.meta
 
 # Client
 #Client/

--- a/GoogleDrive/GoogleDriveManager/Downloader/EntryPoint.cs
+++ b/GoogleDrive/GoogleDriveManager/Downloader/EntryPoint.cs
@@ -14,6 +14,11 @@ namespace Downloader
         {
             var model = GoogleServiceModel.Instance;
             var documentXMLPath = args.Length > 0 ? args[0] : string.Empty;
+            var isOverwrite = args.Length > 1 ? Convert.ToBoolean(args[1]) : false;
+            if (args.Length > 1)
+            {
+                var arg = args[1];
+            }
             if (string.IsNullOrEmpty(documentXMLPath))
             {
                 documentXMLPath = "../../../res/config.xml";
@@ -111,7 +116,7 @@ namespace Downloader
                 model.Download(source, downloadPath);
 
                 // 解凍.
-                ZipModel.Uncompression(downloadPath, destination);
+                ZipModel.Uncompression(downloadPath, destination, isOverwrite);
             }
 
             // 一時保存に使ったフォルダを削除.

--- a/GoogleDrive/GoogleDriveManager/GoogleDriveManager/src/ZipModel.cs
+++ b/GoogleDrive/GoogleDriveManager/GoogleDriveManager/src/ZipModel.cs
@@ -57,7 +57,7 @@ namespace Model
         public static void Compression(string srcDirPath, string destArcFileName, CompressionLevel compressionLevel, bool includeBaseDirectory) => ZipFile.CreateFromDirectory(srcDirPath, destArcFileName, compressionLevel, includeBaseDirectory);
 
         /// 解凍
-        public static void Uncompression(string srcArcFilePath, string destPath, bool isOverwrite = true)
+        public static void Uncompression(string srcArcFilePath, string destPath, bool isOverwrite = false)
         {
             if (!File.Exists(srcArcFilePath))
             {

--- a/GoogleDrive/download_gRPC_plugins.bat
+++ b/GoogleDrive/download_gRPC_plugins.bat
@@ -1,12 +1,12 @@
 @echo off
 set DEBUG_EXE_PATH=%~dp0bin\Debug\net5.0\Downloader.exe
-set RESOURCE_ROOT=%~dp0res\config.xml
+set RESOURCE_ROOT=%~dp0res\project_setting.xml
 
 REM DEBUGバイナリ優先
 if exist %DEBUG_EXE_PATH% (
 
     cd %~dp0bin\Debug\net5.0\
-    call %DEBUG_EXE_PATH% %RESOURCE_ROOT% true
+    call %DEBUG_EXE_PATH% %RESOURCE_ROOT%
     exit /b 0
 )
 
@@ -16,7 +16,7 @@ REM RELEASEビルド
 if exist %RELEASE_EXE% (
 
     cd %~dp0bin\Release\net5.0\
-    call %RELEASE_EXE% %RESOURCE_ROOT% true
+    call %RELEASE_EXE% %RESOURCE_ROOT%
     exit /b 0
 )
 

--- a/GoogleDrive/res/project_setting.xml
+++ b/GoogleDrive/res/project_setting.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 絶対パスの方が望ましい. -->
+<config>
+	<!-- credentials.json -->
+	<credentials>../../../res/credentials.json</credentials>
+	<!-- token.json (フォルダ) -->
+	<token>../../../res/token.json/</token>
+	<!-- 一時保存 -->
+	<temp>../../../temp</temp>
+	<!-- Unity Client Folder -->
+	<client>../../../../../Client/</client>
+	<!-- Unity Client Assets Folder -->
+	<assets>../../../../Client/Assets</assets>
+
+	<!-- memo.増やすときは'data'タグ配列を増やす. -->
+	<!-- アップロード関連 -->
+	<upload>
+		<data>
+			<source></source>
+			<destination></destination>
+		</data>
+	</upload>
+	<!-- ダウンロード関連 -->
+	<download>
+		<data>
+			<!--ドライブ上のダウンロード対象ファイル(.zip)-->
+			<source>Template-OnlineProject/ProjectSetting/GRPC.zip</source>
+			<!--ローカル上の配置先-->
+			<destination>../../../../Client/Assets/Plugins/</destination>
+		</data>
+	</download>
+</config>


### PR DESCRIPTION
## 概要

* ignore更新
* Setup.batでやってたことを移植。→ 上書きフラグの関係もあって読み込むのはconfig.xmlとは別のXMLファイル
* そのままのダウンローダーだとディレクトリを上書きしてしまいPluginsフォルダの
中身がさし変わってしまうため上書きしないよう引数([1]でフラグを受け取れるようにした。)