### PR TITLE
【Develop】Jenkinsからビルドを流せるようにビルドコマンドを用意

### DIFF
--- a/Client/Assets/Editor/Build/BuildCommand.cs
+++ b/Client/Assets/Editor/Build/BuildCommand.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Linq;
+using System.Xml.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.VersionControl;
+using UnityEditor.Build.Reporting;
+
+
+public class BuildCommand
+{
+    private const string BuildConfigFilePath = @"Assets\Editor\Build\BuildConfig.xml";
+    //https://blog.applibot.co.jp/2018/08/31/buildplayer-unity-201801/
+    [MenuItem("Build/BuildFromXML")]
+    public static void BuildFromXML()
+    {
+        if (!File.Exists(BuildConfigFilePath))
+        {
+            throw new FileNotFoundException($"{Path.GetFullPath(BuildConfigFilePath)}", BuildConfigFilePath);
+        }
+        var doc = XDocument.Load(BuildConfigFilePath);
+        const string RootTag = @"Root";
+        var root = doc.Element(RootTag);
+        const string ScenesTag = @"Scenes";
+        var scenes = root.Element(ScenesTag).Elements().Select(x => x.Value).ToArray();
+
+        const string configsTag = @"Configs";
+        const string platformTag = @"platform";
+        const string outputTag = @"output";
+        const string optionTag = @"options";
+        bool resultContains = false;
+        foreach (var config in root.Elements(configsTag))
+        {
+            var outputDir = config.Element(outputTag).Value;
+            if (!Directory.Exists(outputDir))
+            {
+                Directory.CreateDirectory(outputDir);
+            }
+
+            var platform = config.Element(platformTag).Value switch
+            {
+                @"Windows" => BuildTarget.StandaloneWindows64,
+                @"Windows x86" => BuildTarget.StandaloneWindows,
+                @"OSX" => BuildTarget.StandaloneOSX,
+                @"iOS" => BuildTarget.iOS,
+                @"Android" => BuildTarget.Android,
+                // 現在の設定.
+                _ => EditorUserBuildSettings.activeBuildTarget,
+            };
+
+            int value;
+            if (!int.TryParse(config.Element(optionTag).Value, out value))
+            {
+                value = (int)BuildOptions.None;
+            }
+            var option = (BuildOptions)value;
+            var report = BuildPipeline.BuildPlayer(
+               scenes,
+               outputDir,
+               platform,
+               option);
+
+            var msg = report.summary.result switch
+            {
+                BuildResult.Succeeded => $"[BuildResult]Success.{Environment.NewLine}出力先:{outputDir}{Environment.NewLine}Platform:{platform}{Environment.NewLine}Options:{option}",
+                BuildResult.Cancelled => $"[BuildResult]Warning.{Environment.NewLine}{string.Join($"{Environment.NewLine}", report.steps.Select(x => x.messages))}",
+                BuildResult.Failed => $"[BuildResult]Failed.{Environment.NewLine}{string.Join($"{Environment.NewLine}", report.steps.Select(x => x.messages))}",
+                BuildResult.Unknown => $"[BuildResult]Unknown.{Environment.NewLine}{string.Join($"{Environment.NewLine}", report.steps.Select(x => x.messages))}",
+                _ => $"[BuildResult]default.{Environment.NewLine}{string.Join($"{Environment.NewLine}", report.steps.Select(x => x.messages))}",
+            };
+
+            switch (report.summary.result)
+            {
+                case BuildResult.Succeeded:
+                    Debug.Log(msg);
+                    resultContains = true;
+                    break;
+                case BuildResult.Cancelled:
+                    Debug.LogWarning(msg);
+                    break;
+                case BuildResult.Unknown:
+                case BuildResult.Failed:
+                default:
+                    Debug.LogError(msg);
+                    break;
+            };
+        }
+
+        EditorApplication.Exit(resultContains ? 0 : 1);
+    }
+}

--- a/Client/Assets/Editor/Build/BuildCommand.cs.meta
+++ b/Client/Assets/Editor/Build/BuildCommand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ec71be9f8ea26e478afbfdacab10c2a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Editor/Build/BuildConfig.xml
+++ b/Client/Assets/Editor/Build/BuildConfig.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="SHIFT_JIS"?>
+
+<Root>
+    <!-- 
+        ビルド対象のシーン.
+        indexは上から順.
+        *.unity
+    -->
+    <Scenes>
+        <scene></scene>
+    </Scenes>
+
+    <Configs>
+        <Config>
+            <platform></platform>
+            <output></output>
+            <options></options>
+        </Config>
+            
+    </Configs>
+</Root>

--- a/Client/Assets/Editor/Build/BuildConfig.xml
+++ b/Client/Assets/Editor/Build/BuildConfig.xml
@@ -7,14 +7,18 @@
         *.unity
     -->
     <Scenes>
-        <scene></scene>
+        <scene>Assets/Scenes/SampleScene.unity</scene>
     </Scenes>
 
     <Configs>
         <Config>
-            <platform></platform>
-            <output></output>
-            <options></options>
+            <platform>Windows</platform>
+            <!-- 
+                .sln以下に含められない。
+                .exeの拡張子まで指定する必要がある。
+            -->
+            <output>../Exe/CL/Client.exe</output>
+            <options>0</options>
         </Config>
             
     </Configs>

--- a/Client/Assets/Editor/Build/BuildConfig.xml.meta
+++ b/Client/Assets/Editor/Build/BuildConfig.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 323159761054fe8428ca4be4587f1d45
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Editor/Build/ProcessBuilder.cs
+++ b/Client/Assets/Editor/Build/ProcessBuilder.cs
@@ -65,6 +65,7 @@ namespace API.Process
         //  ビルド前実行
         public void OnPreprocessBuild(BuildReport report)
         {
+            Debug.Log($"[BuildEvent]Preprocess build event.");
             if(IsDevelopment(report))
             {
 
@@ -74,6 +75,7 @@ namespace API.Process
         //ビルド後実行
         public void OnPostprocessBuild(BuildReport report)
         {
+            Debug.Log($"[BuildEvent]Postprocess build event.");
             if(IsDevelopment(report))
             {
 


### PR DESCRIPTION
## 概要

Jenkins(CIツール)からビルド実行用にビルドコマンドを実装。
xmlファイルに設定を書き込んで使う。

```
        <Config>
            <platform>プラットフォーム</platform>
            <output>書き出し先</output>
            <options>オプション</options>
        </Config>
```
`Config`の数だけ回す。