### PR TITLE
【Develop】Editor上で作業中に音楽を聞けるようにした

### DIFF
--- a/Client/Assembly-CSharp-Editor.csproj
+++ b/Client/Assembly-CSharp-Editor.csproj
@@ -56,6 +56,7 @@
     <Analyzer Include="C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\Extensions\Microsoft\Visual Studio Tools for Unity\Analyzers\Microsoft.Unity.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Assets\Editor\SoundPlayer\SoundPlayer.editor.cs" />
     <Compile Include="Assets\Editor\Expansion\EditorApplication\EditorApplicationExpansion.cs" />
     <Compile Include="Assets\Editor\Build\SymbolicLink.cs" />
     <Compile Include="Assets\Editor\AssetPostprocessor\IAssetPostprocess.cs" />
@@ -71,6 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\Editor\Build\BuildConfig.xml" />
+    <None Include="Assets\Editor\SoundPlayer\editor.xml" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="UnityEngine">

--- a/Client/Assembly-CSharp.csproj
+++ b/Client/Assembly-CSharp.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Assets\Scripts\Common\Pool\ObjectPoolCollectionBase.cs" />
     <Compile Include="Assets\Scripts\Protocol\CSharp\Protocol.cs" />
     <Compile Include="Assets\Scripts\Masters\Table\Importer\TableImporter.cs" />
+    <Compile Include="Assets\Scripts\Expansions\Windows\WindowsExpansion.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\ExternalResources\Masters.xml" />

--- a/Client/Assets/Editor/SoundPlayer.meta
+++ b/Client/Assets/Editor/SoundPlayer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1fff74bb77c576a4ba3906d1c4f6ed3a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Editor/SoundPlayer/SoundPlayer.editor.cs
+++ b/Client/Assets/Editor/SoundPlayer/SoundPlayer.editor.cs
@@ -1,0 +1,222 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using UnityEngine.Networking;
+using Expansion;
+
+namespace Editor.Expansion
+{
+    public class SoundPlayer : EditorWindow
+    {
+        private static SoundPlayer Instance { get; } = new SoundPlayer();
+
+        private const string WindowName = @"Sound Player in Editor";
+        #region XML
+        private const string RootTag = @"Root";
+        private const string ResourcesTag = @"Resources";
+        private const string ResourceTag = @"Resource";
+        private const string EnableTag = @"enable";
+        private const string UriTag = @"uri";
+        private string xmlUri = @"Assets/Editor/SoundPlayer/editor.xml";
+        #endregion
+        private AudioSource source = null;
+        private AudioListener listener = null;
+        private List<AudioClip> clipList = null;
+        private bool isStreaming = true;
+        private int index = 0;
+        // Update
+        private bool isUpdate = true;
+
+        [ExecuteInEditMode]
+        private void Update()
+        {
+            if (!isUpdate) return;
+
+            if (!Instance.source.isPlaying)
+            {
+                NextAudioList();
+            }
+        }
+
+        [MenuItem("Sound/PlayInEditor")]
+        private static void PlayInEditor()
+        {
+            if (Instance.clipList.Count <= 0)
+            {
+                Debug.LogError($"clip list is nothing.");
+                return;
+            }
+
+            Instance.index = Math.Clamp(Instance.index, 0, Instance.clipList.Count);
+            Instance.source.clip = Instance.clipList[Instance.index];
+            Instance.source.Play();
+        }
+
+        [MenuItem("Sound/SoundPlayerInEditorWindow")]
+        private static void ShowInEditorWindow()
+        {
+            EditorWindow.GetWindow<SoundPlayer>(true, WindowName, true);
+        }
+
+        private void Setup()
+        {
+            Cleanup();
+            listener = FindObjectOfType<AudioListener>(true);
+            if(listener==null)
+            {
+                listener = new AudioListener();
+            }
+            if (clipList == null)
+            {
+                clipList = new List<AudioClip>();
+            }
+            source = FindObjectOfType<AudioSource>();
+            if(source == null)
+            {
+                source = new GameObject("AudioSource").AddComponent<AudioSource>();
+            }
+        }
+
+        private void Cleanup()
+        {
+            if (clipList != null)
+            {
+                clipList.ForEach(clip =>
+                {
+                    if (clip != null)
+                    {
+                        clip.UnloadAudioData();
+                    }
+                    clip = null;
+                });
+                clipList.Clear();
+            }
+            clipList = null;
+            listener = null;
+            if (source != null)
+            {
+                source.Stop();
+            }
+            source = null;
+        }
+
+        [MenuItem("Assets/Sound/LoadAndPlayInXML")]
+        private static void LoadAudioClipAndPlayInXML()
+        {
+            var ext = Path.GetExtension(Instance.xmlUri).ToLower();
+            if (ext != @".xml" || !File.Exists(Instance.xmlUri))
+            {
+                Debug.LogError($"Extension:{ext} uri:{Instance.xmlUri}");
+                Instance.Cleanup();
+                return;
+            }
+
+            Instance.Setup();
+
+            var doc = XDocument.Load(Instance.xmlUri);
+            var root = doc.Element(RootTag);
+            var resources = root.Elements(ResourcesTag);
+            var elements = resources.Elements(ResourceTag);
+            foreach (var element in elements)
+            {
+                var enable = element.Element(EnableTag).Value;
+                var uri = WindowsExpansion.Convert(element.Element(UriTag).Value);
+
+                if (!enable.Equals("true", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (!File.Exists(uri))
+                {
+                    Debug.LogError($"FileNotFoundException:{uri}");
+                    continue;
+                }
+
+                var e = Instance.GetDownloadAudioClip(uri, Instance.isStreaming, (clip) =>
+                {
+                    if (clip != null)
+                    {
+                        Instance.clipList.Add(clip);
+                    }
+                });
+                while (e.MoveNext()) { }
+            }
+            PlayInEditor();
+        }
+
+        [MenuItem("Assets/Sound/NextAudioList")]
+        private static void NextAudioList()
+        {
+            if (Instance.clipList.Count <= 0)
+            {
+                Debug.LogError($"clip list is nothing.");
+                return;
+            }
+
+            Instance.index = ++Instance.index % Instance.clipList.Count;
+            Instance.source.clip = Instance.clipList[Instance.index];
+            if (Instance.source.isPlaying)
+            {
+                Instance.source.Stop();
+            }
+            Instance.source.Play();
+        }
+
+        [MenuItem("Assets/Sound/PrevAudioList")]
+        private static void PrevAudioList()
+        {
+            if (Instance.clipList.Count <= 0)
+            {
+                Debug.LogError($"clip list is nothing.");
+                return;
+            }
+
+            Instance.index = --Instance.index < 0 ? Instance.clipList.Count - 1 : Instance.index % Instance.clipList.Count;
+            Instance.source.clip = Instance.clipList[Instance.index];
+            if (Instance.source.isPlaying)
+            {
+                Instance.source.Stop();
+            }
+            Instance.source.Play();
+        }
+
+        private IEnumerator GetDownloadAudioClip(string uri, bool isStreaming, Action<AudioClip> action)
+        {
+            using (var request = UnityWebRequestMultimedia.GetAudioClip(uri, GetAudioType(uri)))
+            {
+                ((DownloadHandlerAudioClip)request.downloadHandler).streamAudio = isStreaming;
+
+                request.SendWebRequest();
+                while (!request.isDone) yield return null;
+
+                if (request.result == UnityWebRequest.Result.Success)
+                {
+                    var content = DownloadHandlerAudioClip.GetContent(request);
+                    action?.Invoke(content);
+                }
+                else
+                {
+                    Debug.LogError($"Result:{request.result}{Environment.NewLine}Error:{request.error}{Environment.NewLine}uri:{uri}");
+                }
+            }
+        }
+
+        private static AudioType GetAudioType(string uri)
+        {
+            return Path.GetExtension(uri).ToLower() switch
+            {
+                @".mp3" => AudioType.MPEG,
+                @".wav" => AudioType.WAV,
+                @".wave" => AudioType.WAV,
+                @".ogg" => AudioType.OGGVORBIS,
+                _ => AudioType.UNKNOWN,
+            };
+        }
+    }
+}

--- a/Client/Assets/Editor/SoundPlayer/SoundPlayer.editor.cs.meta
+++ b/Client/Assets/Editor/SoundPlayer/SoundPlayer.editor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ae854239292f8944ad5438c1b78ad29
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Editor/SoundPlayer/editor.xml
+++ b/Client/Assets/Editor/SoundPlayer/editor.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="SHIFT_JIS"?>
+
+<Root>
+    <!-- 
+        audio file.
+        indexは上から順.
+    -->
+    <Resources>
+        <Resource>
+            <enable>true</enable>
+            <uri>%USERPROFILE%\Documents\明日を漁れ.mp3</uri>
+        </Resource>
+        <Resource>
+            <enable>true</enable>
+            <uri>%USERPROFILE%\Documents\LAMUNATION！VOCAL_COLLECTION.wav</uri>
+        </Resource>
+    </Resources>
+</Root>

--- a/Client/Assets/Editor/SoundPlayer/editor.xml.meta
+++ b/Client/Assets/Editor/SoundPlayer/editor.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f9a5c80ef66c5dd49833df686b170586
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scenes/2D_sample.unity
+++ b/Client/Assets/Scenes/2D_sample.unity
@@ -1,0 +1,728 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &80903083
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 80903086}
+  - component: {fileID: 80903085}
+  - component: {fileID: 80903084}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!81 &80903084
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 80903083}
+  m_Enabled: 1
+--- !u!20 &80903085
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 80903083}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &80903086
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 80903083}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &535837171
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 535837173}
+  - component: {fileID: 535837172}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &535837172
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 535837171}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d75ba865de9c56c4c9ae6124de17bd1f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &535837173
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 535837171}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &733669207
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 733669211}
+  - component: {fileID: 733669210}
+  - component: {fileID: 733669209}
+  - component: {fileID: 733669208}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &733669208
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 733669207}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &733669209
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 733669207}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &733669210
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 733669207}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &733669211
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 733669207}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &988051981
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 988051984}
+  - component: {fileID: 988051983}
+  - component: {fileID: 988051982}
+  m_Layer: 0
+  m_Name: Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &988051982
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 988051981}
+  m_Enabled: 1
+--- !u!20 &988051983
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 988051981}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.990566, g: 0.4149163, b: 0.4149163, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &988051984
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 988051981}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1441499018
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1441499020}
+  - component: {fileID: 1441499019}
+  m_Layer: 0
+  m_Name: MasterData
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1441499019
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1441499018}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d57797e35eb4d043b528edd402f82db, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1441499020
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1441499018}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!83 &1589789450
+AudioClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_LoadType: 0
+  m_Channels: 0
+  m_Frequency: 0
+  m_BitsPerSample: 0
+  m_Length: 0
+  m_IsTrackerFormat: 0
+  m_Ambisonic: 0
+  m_SubsoundIndex: 0
+  m_PreloadAudioData: 1
+  m_LoadInBackground: 0
+  m_Legacy3D: 0
+  m_Resource:
+    m_Source: 
+    m_Offset: 0
+    m_Size: 0
+  m_CompressionFormat: 0
+  m_EditorResource:
+    m_Source: 
+    m_Offset: 0
+    m_Size: 0
+  m_EditorCompressionFormat: 0
+--- !u!1 &1757588321
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1757588323}
+  - component: {fileID: 1757588322}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1757588322
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1757588321}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1757588323
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1757588321}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &2033505349
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2033505351}
+  - component: {fileID: 2033505350}
+  m_Layer: 0
+  m_Name: AudioSource
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!82 &2033505350
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2033505349}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 1589789450}
+  m_PlayOnAwake: 1
+  m_Volume: 0.449
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!4 &2033505351
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2033505349}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Client/Assets/Scenes/2D_sample.unity.meta
+++ b/Client/Assets/Scenes/2D_sample.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c421a44949146604b9eef39ca1775cca
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/Expansions/Windows.meta
+++ b/Client/Assets/Scripts/Expansions/Windows.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c16c3f6429f04634ba8a9446acb45d10
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/Expansions/Windows/WindowsExpansion.cs
+++ b/Client/Assets/Scripts/Expansions/Windows/WindowsExpansion.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+namespace Expansion
+{
+    public static class WindowsExpansion
+    {
+        /// <summary>
+        /// %USERNAME%
+        /// </summary>
+        public static string USERNAME { get { return Environment.UserName; } }
+
+        private static readonly Dictionary<string, string> environmentVariableDict = new Dictionary<string, string>()
+        {
+            {"%USERNAME%",Environment.UserName},
+            {"%USERPROFILE%",Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) },
+        };
+
+        public static string Convert(string pathWithExtension)
+        {
+            var splits = pathWithExtension.Split(Path.DirectorySeparatorChar);
+            if (splits == null)
+            {
+                return string.Empty;
+            }
+
+            var conv = string.Join(Path.DirectorySeparatorChar, splits.Select(str =>
+            {
+                if (environmentVariableDict.ContainsKey(str))
+                {
+                    return environmentVariableDict[str];
+                }
+                return str;
+            }));
+            return conv;
+        }
+
+#if UNITY_EDITOR
+        [MenuItem("Assets/Test/Log/WindowsEnvironmentList")]
+        public static void Log()
+        {
+            foreach(var v in Enum.GetValues(typeof(Environment.SpecialFolder)))
+            {
+                Debug.Log($"{(int)v}:<color=green>{v}</color> {Environment.GetFolderPath((Environment.SpecialFolder)v)}");
+            }
+        }
+#endif
+    }
+}

--- a/Client/Assets/Scripts/Expansions/Windows/WindowsExpansion.cs.meta
+++ b/Client/Assets/Scripts/Expansions/Windows/WindowsExpansion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 02dd084dffeaae540a1713e128a1f70c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION

## 概要

MenuItemの`Sound/LoadAndPlayInXML`をトリガーにXMLに定義したパスの音楽ファイルを再生する。
※1 Resource（音楽ファイル）はAssets直下じゃなくてもいい。
※2 USERNAMEが変わることを想定しWINDOWS環境変数として%USERNAME%と%USERPROFILE%を変換する機構を用意した。

![sound_editor](https://user-images.githubusercontent.com/37837548/180237340-304b78b0-cfde-48ae-bf46-c70fbfc8572b.png)


## TODO

上部のSoundメニューから展開予定のSoundEditorWindowは未定義。
（再生中の音楽ファイルのインデックスの変更や動的なファイルの追加など想定していた）

![sound_editor_window](https://user-images.githubusercontent.com/37837548/180239956-7268c281-d5ee-4b92-8a8a-b106a27eca88.png)

