### PR TITLE
【Bugfix】Sound/AudioManager周りの実装で不足データがあったので追加

### DIFF
--- a/Client/Assets/Editor/Sound/AudioChannel.inspector.cs.meta
+++ b/Client/Assets/Editor/Sound/AudioChannel.inspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 57139b3596fa75847abf79c87ce1fabf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/Sound.meta
+++ b/Client/Assets/Scripts/Sound.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 873478eca0d2f2e46b5e2a757308a7b7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/Sound/AudioData.cs
+++ b/Client/Assets/Scripts/Sound/AudioData.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Sound
+{
+    public class AudioData
+    {
+        public AudioClip Clip { get; private set; }
+    }
+}

--- a/Client/Assets/Scripts/Sound/AudioData.cs.meta
+++ b/Client/Assets/Scripts/Sound/AudioData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 33a62b102e0a24a4a963e9e5ca12ece4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要

* #78
AudioManager実装に際し、参照していたAudioDataクラスが漏れてコンパイルエラーを起こしていたの修正
* 挙がっていなかったメタファイルを追加
