### PR TITLE
【Develop】lua5.4動作サンプル

### DIFF
--- a/NativePlugins/ExecutionProject/ExecutionProject.vcxproj
+++ b/NativePlugins/ExecutionProject/ExecutionProject.vcxproj
@@ -21,11 +21,15 @@
   <ItemGroup>
     <ClCompile Include="include\EntryPoint\EntryPoint.cpp" />
     <ClCompile Include="include\sample\lua\lua_sample_51.cpp" />
+    <ClCompile Include="include\sample\lua\lua_sample_54.cpp" />
+    <ClCompile Include="include\sample\lua\lua_sample_factor.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\sample\lua\Ilua_sample.hpp" />
     <ClInclude Include="include\sample\lua\lua_sample_51.hpp" />
+    <ClInclude Include="include\sample\lua\lua_sample_54.hpp" />
     <ClInclude Include="include\sample\lua\lua_sample_dummy.hpp" />
+    <ClInclude Include="include\sample\lua\lua_sample_factor.hpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
@@ -106,13 +110,13 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\include;$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\include;$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.4\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\bin\$(Platform)\$(Configuration);$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.1;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>ExternalDynamicLinkLibrary.lib;lua5.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\bin\$(Platform)\$(Configuration);$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.1;$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.4;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ExternalDynamicLinkLibrary.lib;lua54.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>REM 自作ネイティブプラグイン(dll)
@@ -168,7 +172,7 @@ xcopy %RESOURCES_DIR% $(OUTDIR)resources\ /r /e /y /d</Command>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\include;$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\include;$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.4\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
@@ -176,8 +180,8 @@ xcopy %RESOURCES_DIR% $(OUTDIR)resources\ /r /e /y /d</Command>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\bin\$(Platform)\$(Configuration);$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.1;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>ExternalDynamicLinkLibrary.lib;lua5.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\bin\$(Platform)\$(Configuration);$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.1;$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.4;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ExternalDynamicLinkLibrary.lib;lua54.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>REM 自作ネイティブプラグイン(dll)
@@ -232,13 +236,13 @@ xcopy %RESOURCES_DIR% $(OUTDIR)resources\ /r /e /y /d</Command>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\include;$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\include;$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.4\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\bin\$(Platform)\$(Configuration);$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.1;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>ExternalDynamicLinkLibrary.lib;lua5.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\bin\$(Platform)\$(Configuration);$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.1;$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.4;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ExternalDynamicLinkLibrary.lib;lua54.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>REM 自作ネイティブプラグイン(dll)
@@ -294,7 +298,7 @@ xcopy %RESOURCES_DIR% $(OUTDIR)resources\ /r /e /y /d</Command>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\include;$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\include;$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.4\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
@@ -302,8 +306,8 @@ xcopy %RESOURCES_DIR% $(OUTDIR)resources\ /r /e /y /d</Command>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\bin\$(Platform)\$(Configuration);$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.1;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>ExternalDynamicLinkLibrary.lib;lua5.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)ExternalDynamicLinkLibrary\bin\$(Platform)\$(Configuration);$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.1;$(SolutionDir)ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.4;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ExternalDynamicLinkLibrary.lib;lua54.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>REM 自作ネイティブプラグイン(dll)

--- a/NativePlugins/ExecutionProject/ExecutionProject.vcxproj.filters
+++ b/NativePlugins/ExecutionProject/ExecutionProject.vcxproj.filters
@@ -24,6 +24,12 @@
     <ClCompile Include="include\sample\lua\lua_sample_51.cpp">
       <Filter>Lua</Filter>
     </ClCompile>
+    <ClCompile Include="include\sample\lua\lua_sample_54.cpp">
+      <Filter>Lua</Filter>
+    </ClCompile>
+    <ClCompile Include="include\sample\lua\lua_sample_factor.cpp">
+      <Filter>Lua</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\sample\lua\lua_sample_51.hpp">
@@ -33,6 +39,12 @@
       <Filter>Lua</Filter>
     </ClInclude>
     <ClInclude Include="include\sample\lua\lua_sample_dummy.hpp">
+      <Filter>Lua</Filter>
+    </ClInclude>
+    <ClInclude Include="include\sample\lua\lua_sample_54.hpp">
+      <Filter>Lua</Filter>
+    </ClInclude>
+    <ClInclude Include="include\sample\lua\lua_sample_factor.hpp">
       <Filter>Lua</Filter>
     </ClInclude>
   </ItemGroup>

--- a/NativePlugins/ExecutionProject/include/EntryPoint/EntryPoint.cpp
+++ b/NativePlugins/ExecutionProject/include/EntryPoint/EntryPoint.cpp
@@ -12,9 +12,7 @@
 #include<lua.hpp>
 #include "edlpch.hpp"
 #include "../../../ExternalDynamicLinkLibrary/include/Sample/Sample.hpp"
-#include "../../../ExternalDynamicLinkLibrary/include/lua_wrapper.hpp"
-#include "../../ExecutionProject/include/sample/lua/lua_sample_51.hpp"
-#include "../../ExecutionProject/include/sample/lua/lua_sample_dummy.hpp"
+#include "../../ExecutionProject/include/sample/lua/lua_sample_factor.hpp"
 #define SUCCESS 0
 #define FAILED -1
 
@@ -42,15 +40,10 @@ int main(int argNum, const char* argments)
 	*/
 	setlocale(LC_ALL, ".UTF8");
 
+	auto factor = new lua_sample_factor();
+	auto lua = factor->create();
+	delete factor;
 
-	Ilua_sample* lua =
-#if LUA_VERSION_NUM == 501
-		new lua_sample_51()
-#elif LUA_VERSION_NUM==504
-#else
-		new lua_sample_dummy()
-#endif
-		;
 	/*
 	* @brief	Luaで定義した変数の取得仕方のサンプル.
 	lua->get_lua_value_sample();
@@ -68,13 +61,13 @@ int main(int argNum, const char* argments)
 
 	/*
 	* @brief	Luaテーブルの挙動サンプル
+	lua->do_lua_table_sample();
 	*/
-	//lua->do_lua_table_sample();
 
 	/*
 	* @brief	LuaでC++の関数を呼び出すサンプル
-	*/
 	lua->do_cpp_method_sample();
+	*/
 
 	// メモリ開放
 	delete lua;

--- a/NativePlugins/ExecutionProject/include/sample/lua/lua_sample_51.hpp
+++ b/NativePlugins/ExecutionProject/include/sample/lua/lua_sample_51.hpp
@@ -1,12 +1,11 @@
 //参考:http://marupeke296.com/LUA_main.html
 #pragma once
-#include <lua.hpp>
-#include <string>
-#include "edlpch.hpp"
 #include "Ilua_sample.hpp"
-
 #pragma region Lua ver_5.1
 #if LUA_VERSION_NUM == 501
+#include <string>
+#include "edlpch.hpp"
+
 class lua_sample_51
 	:public Ilua_sample
 {
@@ -20,8 +19,6 @@ public:
 	void do_lua_table_sample()override;
 	void do_cpp_method_sample()override;
 private:
-	lua_State* m_pState = nullptr;
-
 	/*
 		@brief	lua_StateにLuaファイルをロード.
 	*/

--- a/NativePlugins/ExecutionProject/include/sample/lua/lua_sample_54.cpp
+++ b/NativePlugins/ExecutionProject/include/sample/lua/lua_sample_54.cpp
@@ -1,0 +1,251 @@
+#include "lua_sample_54.hpp"
+#include<format>
+
+#if LUA_VERSION_NUM == 504
+
+int Linear(lua_State*L) 
+{
+	float a = static_cast<float>(lua_tonumber(L, 1));
+	float b = static_cast<float>(lua_tonumber(L, 2));
+	float t = static_cast<float>(lua_tonumber(L, 3));
+
+	// 処理.
+	float result = (1.0f - t) * a + t * b;
+
+	/*
+		スタック削除.
+	*/
+	lua_pop(L, lua_gettop(L));
+
+	/*
+		スタックに戻り値を積む.
+	*/
+	lua_pushnumber(L, result);
+
+	// 戻り値の数.
+	return 1;
+}
+
+void lua_sample_54::stack_print(lua_State* L)
+{
+	const int num = lua_gettop(L);
+
+	std::cout << "lua_State->stack print" << std::endl;
+
+	if (num == 0) {
+		std::cout << "No stack." << std::endl;
+		return;
+	}
+
+	for (int i = num; i >= 1; i--) {
+		/*
+			@MEMO	formatはC++20の機能.
+		*/
+		std::cout << std::format("↑{0}(↓{1}):", i, -num + i - 1);
+
+		int type = lua_type(L, i);
+		std::string str;
+		switch (type) {
+		case LUA_TNIL:
+			str = std::string("NIL");
+			break;
+		case LUA_TBOOLEAN:
+			str = std::format("BOOLEAN {}", lua_toboolean(L, i) ? "true" : "false");
+			break;
+		case LUA_TLIGHTUSERDATA:
+			str = std::string("LIGHTUSERDATA");
+			break;
+		case LUA_TNUMBER:
+			str = std::format("NUMBER {}", lua_tonumber(L, i));
+			break;
+		case LUA_TSTRING:
+			str = std::format("STRING {}", lua_tostring(L, i));
+			break;
+		case LUA_TTABLE:
+			str = std::string("TABLE");
+			break;
+		case LUA_TFUNCTION:
+			printf("\n");
+			str = std::string("FUNCTION");
+			break;
+		case LUA_TUSERDATA:
+			str = std::string("USERDATA");
+			break;
+		case LUA_TTHREAD:
+			str = std::string("THREAD");
+			break;
+		}
+		std::cout << str << std::endl;
+	}
+}
+
+void lua_sample_54::get_lua_value_sample()
+{
+	lua_State* L = luaL_newstate();
+	if (!load(L, "resources/lua/getvalue_sample.lua")) {
+		return;
+	}
+
+	// getglobalメソッドを呼ぶことでスタックに積まれる.
+	lua_getglobal(L, "Width");
+	lua_getglobal(L, "Height");
+	lua_getglobal(L, "Name");
+	stack_print(L);
+
+	auto width = static_cast<int>(lua_tonumber(L, 1));
+	auto height = static_cast<int>(lua_tonumber(L, 2));
+	auto name = static_cast<std::string>(lua_tostring(L, 3));
+
+	std::cout << "load lua value to cpp." << std::endl;
+	VARARGOUT(width);
+	VARARGOUT(height);
+	VARARGOUT(name);
+
+	lua_close(L);
+}
+
+void lua_sample_54::do_lua_method_sample()
+{
+	lua_State* L = luaL_newstate();
+	if (!load(L, "resources/lua/domethod_sample.lua")) {
+		return;
+	}
+
+	// スタックに呼び出すメソッドを登録しとく.
+	lua_getglobal(L, "calc");
+
+	// 引数指定.
+	lua_pushnumber(L, 10);
+	lua_pushnumber(L, 8);
+
+	// スタック表示.
+	stack_print(L);
+
+	// 関数実行.
+	if (lua_pcall(L, 2, 4, 0))
+	{
+		std::cout << std::format("{}", lua_gettop(L)) << std::endl;
+		lua_close(L);
+		return;
+	}
+
+	stack_print(L);
+
+	// 戻り値を取得.
+	int add = static_cast<int>(lua_tonumber(L, 1));
+	int sub = static_cast<int>(lua_tonumber(L, 2));
+	int mul = static_cast<int>(lua_tonumber(L, 3));
+	float dev = static_cast<float>(lua_tonumber(L, 4));
+
+	std::cout << "calc lua function to cpp." << std::endl;
+	VARARGOUT(add);
+	VARARGOUT(sub);
+	VARARGOUT(mul);
+	VARARGOUT(dev);
+
+	lua_close(L);
+}
+
+void lua_sample_54::do_lua_coroutine_sample()
+{
+	auto L = luaL_newstate();
+	luaopen_base(L);
+
+	/*
+		@memo	lua_openlibs ← これを呼ばないと"attempt to call global 'coroutine' (a nil value)"coroutineが定義されてないってエラーがでるっぽい.
+	*/
+	luaL_openlibs(L);
+
+	if (!load(L, "resources/lua/docoroutine_sample_54.lua")) {
+		return;
+	}
+
+	char c;
+	/*
+		@memo	Lua5.1との変更点.
+		@detail		
+		コルーチンを開始するには、メイン関数と引数をスレッドの空スタックにプッシュし、nargs を引数の数として lua_resume を呼びます。
+		この呼び出しはコルーチンの実行が停止あるいは完了したときに返ります。
+		関数が返るとき *nresults は更新され、スタックトップには関数本体の return あるいは lua_yield に渡された *results 個の値が存在します。
+		この関数はコルーチンが yield すると LUA_YIELD を返し、コルーチンが実行をエラーを出さずに終了すると LUA_OK を返します。
+		そのときエラーオブジェクトがスタックトップに存在します。
+		コルーチンを再開するには、yield された *nresults 個の値をスタックから取り除き、yield の返り値となる値をプッシュし、それから lua_resume を呼びます。
+		パラメータ from は L を再開させるコルーチンを表します。
+		そのようなコルーチンが存在しない場合1には from を NULL にできます。
+	*/
+	int* results = new int;
+
+	// コルーチン(スレッド)作成.
+	auto co = lua_newthread(L);
+
+	// スタックにコルーチン用のメソッドを登録.
+	lua_getglobal(co, "step");
+
+	int result;
+	while (lua_resume(co, NULL, 0, results))
+	{
+		stack_print(co);
+		auto str = lua_tostring(co, 1);
+		std::cout << "出力:" << str << std::endl;
+		c = getchar();
+	}
+	delete results;
+
+	lua_close(L);
+}
+
+void lua_sample_54::do_lua_table_sample()
+{
+	lua_State* L = luaL_newstate();
+	luaopen_base(L);
+	if (!load(L, "resources/lua/dotable_sample.lua")) {
+		return;
+	}
+
+	lua_close(L);
+}
+
+void lua_sample_54::do_cpp_method_sample()
+{
+	auto L = luaL_newstate();
+
+	/*
+		@brief		luaL_Stateに関数を登録.
+		@param1:	lua_Stateのポインタ.
+		@param2:	Lua側への登録名.
+		@param3:	登録する関数ポインタ.
+		@hack:		メンバ関数として登録する際の構文が分からなかったのでグローバル関数として用意したものをバインド.
+	*/
+	//lua_register(L, "func_cpp", &PrintCpp);
+
+	// ↑でバインドした関数を内部的に使っている関数をスタックに登録.
+	//lua_getglobal(L, "print_noarg");
+
+
+	/*
+		@brief	線形補完用のメソッドを登録.
+		@detail	戻り値:float型一つ、引数:float型3つ
+	*/
+	lua_register(L, "Linear", &Linear);
+
+	luaopen_base(L);
+	if (!load(L, "resources/lua/domethod_cpp_sample.lua")) {
+		return;
+	}
+
+	lua_close(L);
+
+}
+
+bool lua_sample_54::load(lua_State* L, std::string path)
+{
+	if (luaL_dofile(L, path.c_str()))
+	{
+		std::cout << lua_tostring(L, lua_gettop(L)) << std::endl;
+		lua_close(L);
+		std::cout << "failed to load lua. path:" << path << std::endl;
+		return false;
+	}
+	return true;
+}
+#endif

--- a/NativePlugins/ExecutionProject/include/sample/lua/lua_sample_54.hpp
+++ b/NativePlugins/ExecutionProject/include/sample/lua/lua_sample_54.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include"Ilua_sample.hpp"
+#pragma region Lua ver_5.4
+#if LUA_VERSION_NUM == 504
+#include <string>
+#include "edlpch.hpp"
+
+class lua_sample_54 :
+    public Ilua_sample
+{
+public:
+    lua_sample_54() {}
+    ~lua_sample_54() {}
+
+	void stack_print(lua_State* L)override;
+	void get_lua_value_sample()override;
+	void do_lua_method_sample()override;
+	void do_lua_coroutine_sample()override;
+	void do_lua_table_sample()override;
+	void do_cpp_method_sample()override;
+
+private:
+	/*
+	@brief	lua_StateにLuaファイルをロード.
+	*/
+	bool load(lua_State* L, std::string path);
+
+};
+
+#endif
+#pragma endregion

--- a/NativePlugins/ExecutionProject/include/sample/lua/lua_sample_factor.cpp
+++ b/NativePlugins/ExecutionProject/include/sample/lua/lua_sample_factor.cpp
@@ -1,0 +1,21 @@
+#include "lua_sample_factor.hpp"
+#include "lua_sample_51.hpp"
+#include "lua_sample_54.hpp"
+#include "lua_sample_dummy.hpp"
+
+Ilua_sample* lua_sample_factor::create()
+{
+	auto lua_sample =
+#if LUA_VERSION_NUM == 501
+		// Lua5.1
+		new lua_sample_51()
+#elif LUA_VERSION_NUM==504
+		// Lua5.4
+		new lua_sample_54()
+#else
+		// É_É~Å[.
+		new lua_sample_dummy()
+#endif
+		;
+	return lua_sample;
+}

--- a/NativePlugins/ExecutionProject/include/sample/lua/lua_sample_factor.hpp
+++ b/NativePlugins/ExecutionProject/include/sample/lua/lua_sample_factor.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include "Ilua_sample.hpp"
+
+class lua_sample_factor
+{
+public:
+	lua_sample_factor() {};
+	~lua_sample_factor() {};
+
+	Ilua_sample* create();
+private:
+
+};

--- a/NativePlugins/ExecutionProject/resources/lua/docoroutine_sample_54.lua
+++ b/NativePlugins/ExecutionProject/resources/lua/docoroutine_sample_54.lua
@@ -1,0 +1,44 @@
+-- Luaのコルーチン
+-- サンプル用のLua
+
+-- C言語側で呼び出すメソッドの定義
+-- C言語で呼び出される前提なら"coroutine.create"でコルーチンを作っておく必要はない.
+function step()
+    print("1st");
+    coroutine.yield("step1: そこは広場だった。");
+    print("2nd");
+    coroutine.yield("step2: 小さな滑り台があった。");
+    print("3rd");
+    coroutine.yield("step3: 昔ここで良く遊んだ事を思い出した。");
+end
+
+--[[
+参考
+https://gist.github.com/hayajo/da35d970d095710e8ec8
+
+CMD 
+Lua構文チェック.
+lua.exe <*.lua>
+
+    
+-- lambdaでコルーチンにメソッドを登録.
+co = coroutine.create(function()
+    coroutine.yield("step1: そこは広場だった。");
+    coroutine.yield("step2: 小さな滑り台があった。");
+    coroutine.yield("step3: 昔ここで良く遊んだ事を思い出した。");
+end)
+
+
+print("--lambda--")
+print(coroutine.resume(co));
+print(coroutine.resume(co));
+print(coroutine.resume(co));
+print(coroutine.resume(co)); -- 空出力.
+
+print("--coroutine.create(step)--")
+co_f = coroutine.create(step);
+print(coroutine.resume(co_f));
+print(coroutine.resume(co_f));
+print(coroutine.resume(co_f));
+print(coroutine.resume(co_f)); -- 空出力.
+]]


### PR DESCRIPTION
## 概要

* #86

5.4でコルーチンの動作が担保できたのでサンプルを挙げる。

結論を載せてしまうと`lua_openlibs`のメソッドが呼び出されていなかった。
ひとまず`lua_resume`の`from`はNULLでいい。