### PR TITLE
【Develop】NativePluginsの形式がスタティックライブラリだったのをDLLに修正

### DIFF
--- a/NativePlugins/ExecutionProject/include/EntryPoint/EntryPoint.cpp
+++ b/NativePlugins/ExecutionProject/include/EntryPoint/EntryPoint.cpp
@@ -10,9 +10,9 @@
 #include <iostream>
 #include <vector>
 #include<lua.hpp>
-#include "edlpch.hpp"
 #include "../../../ExternalDynamicLinkLibrary/include/Sample/Sample.hpp"
 #include "../../ExecutionProject/include/sample/lua/lua_sample_factor.hpp"
+#include "common/edlpch.hpp"
 #define SUCCESS 0
 #define FAILED -1
 

--- a/NativePlugins/ExecutionProject/include/sample/lua/Ilua_sample.hpp
+++ b/NativePlugins/ExecutionProject/include/sample/lua/Ilua_sample.hpp
@@ -1,6 +1,14 @@
 #pragma once
 #include <lua.hpp>
 
+#pragma region •Ï”–¼:’l‚Ìo—Í
+#if DEBUG||_DEBUG
+#define VARARGOUT(var) std::cout<<#var<<":"<<var<<std::endl;
+#else
+#define VARARGOUT(var)
+#endif // DEBUG||_DEBUG
+#pragma endregion
+
 __interface Ilua_sample
 {
 	/*

--- a/NativePlugins/ExecutionProject/include/sample/lua/lua_sample_54.cpp
+++ b/NativePlugins/ExecutionProject/include/sample/lua/lua_sample_54.cpp
@@ -1,3 +1,4 @@
+#include<iostream>
 #include "lua_sample_54.hpp"
 #include<format>
 
@@ -181,7 +182,6 @@ void lua_sample_54::do_lua_coroutine_sample()
 	// スタックにコルーチン用のメソッドを登録.
 	lua_getglobal(co, "step");
 
-	int result;
 	while (lua_resume(co, NULL, 0, results))
 	{
 		stack_print(co);

--- a/NativePlugins/ExecutionProject/include/sample/lua/lua_sample_54.hpp
+++ b/NativePlugins/ExecutionProject/include/sample/lua/lua_sample_54.hpp
@@ -3,7 +3,6 @@
 #pragma region Lua ver_5.4
 #if LUA_VERSION_NUM == 504
 #include <string>
-#include "edlpch.hpp"
 
 class lua_sample_54 :
     public Ilua_sample

--- a/NativePlugins/ExternalDynamicLinkLibrary/ExternalDynamicLinkLibrary.vcxproj
+++ b/NativePlugins/ExternalDynamicLinkLibrary/ExternalDynamicLinkLibrary.vcxproj
@@ -19,16 +19,11 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="include\edlpch.cpp">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
-    </ClCompile>
+    <ClCompile Include="include\common\edlpch.cpp" />
     <ClCompile Include="include\lua_wrapper.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="include\edlpch.hpp" />
+    <ClInclude Include="include\common\edlpch.hpp" />
     <ClInclude Include="include\lua_wrapper.hpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -40,26 +35,26 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -109,15 +104,15 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)\ExternalDynamicLinkLibrary\include;$(SolutionDir)\ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.1\include</AdditionalIncludeDirectories>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <AdditionalIncludeDirectories>$(SolutionDir)$(ProjectName)\include;#$(SolutionDir)$(ProjectName)\dll\$(Platform)\Lua\5.1\include;$(SolutionDir)$(ProjectName)\dll\$(Platform)\Lua\5.4\include</AdditionalIncludeDirectories>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>edlpch.hpp</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)\ExternalDynamicLinkLibrary\dll\$(Platform)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>liblua54.a</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)$(ProjectName)\dll\$(Platform)\Lua\5.4</AdditionalLibraryDirectories>
+      <AdditionalDependencies>lua54.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>
@@ -169,8 +164,8 @@ endlocal</Command>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)\ExternalDynamicLinkLibrary\include;$(SolutionDir)\ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.1\include</AdditionalIncludeDirectories>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <AdditionalIncludeDirectories>$(SolutionDir)$(ProjectName)\include;#$(SolutionDir)$(ProjectName)\dll\$(Platform)\Lua\5.1\include;$(SolutionDir)$(ProjectName)\dll\$(Platform)\Lua\5.4\include</AdditionalIncludeDirectories>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>edlpch.hpp</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
@@ -178,8 +173,8 @@ endlocal</Command>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)\ExternalDynamicLinkLibrary\dll\$(Platform)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>liblua54.a</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)$(ProjectName)\dll\$(Platform)\Lua\5.4</AdditionalLibraryDirectories>
+      <AdditionalDependencies>lua54.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>
@@ -229,15 +224,15 @@ endlocal</Command>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)\ExternalDynamicLinkLibrary\include;$(SolutionDir)\ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.1\include</AdditionalIncludeDirectories>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <AdditionalIncludeDirectories>$(SolutionDir)$(ProjectName)\include;#$(SolutionDir)$(ProjectName)\dll\$(Platform)\Lua\5.1\include;$(SolutionDir)$(ProjectName)\dll\$(Platform)\Lua\5.4\include</AdditionalIncludeDirectories>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>edlpch.hpp</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)\ExternalDynamicLinkLibrary\dll\$(Platform)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>liblua54.a</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)$(ProjectName)\dll\$(Platform)\Lua\5.4</AdditionalLibraryDirectories>
+      <AdditionalDependencies>lua54.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>
@@ -289,8 +284,8 @@ endlocal</Command>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)\ExternalDynamicLinkLibrary\include;$(SolutionDir)\ExternalDynamicLinkLibrary\dll\$(Platform)\Lua\5.1\include</AdditionalIncludeDirectories>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <AdditionalIncludeDirectories>$(SolutionDir)$(ProjectName)\include;#$(SolutionDir)$(ProjectName)\dll\$(Platform)\Lua\5.1\include;$(SolutionDir)$(ProjectName)\dll\$(Platform)\Lua\5.4\include</AdditionalIncludeDirectories>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>edlpch.hpp</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
@@ -298,8 +293,8 @@ endlocal</Command>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)\ExternalDynamicLinkLibrary\dll\$(Platform)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>liblua54.a</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)$(ProjectName)\dll\$(Platform)\Lua\5.4</AdditionalLibraryDirectories>
+      <AdditionalDependencies>lua54.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>

--- a/NativePlugins/ExternalDynamicLinkLibrary/ExternalDynamicLinkLibrary.vcxproj.filters
+++ b/NativePlugins/ExternalDynamicLinkLibrary/ExternalDynamicLinkLibrary.vcxproj.filters
@@ -13,21 +13,24 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
+    <Filter Include="common">
+      <UniqueIdentifier>{09301db8-1bb1-4054-af5a-39bc2d6ffa5c}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="include\lua_wrapper.cpp">
       <Filter>ソース ファイル</Filter>
     </ClCompile>
-    <ClCompile Include="include\edlpch.cpp">
-      <Filter>ソース ファイル</Filter>
+    <ClCompile Include="include\common\edlpch.cpp">
+      <Filter>common</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\lua_wrapper.hpp">
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
-    <ClInclude Include="include\edlpch.hpp">
-      <Filter>ヘッダー ファイル</Filter>
+    <ClInclude Include="include\common\edlpch.hpp">
+      <Filter>common</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/NativePlugins/ExternalDynamicLinkLibrary/include/common/edlpch.cpp
+++ b/NativePlugins/ExternalDynamicLinkLibrary/include/common/edlpch.cpp
@@ -1,0 +1,5 @@
+#include "common/edlpch.hpp"
+
+void a() {
+
+}

--- a/NativePlugins/ExternalDynamicLinkLibrary/include/common/edlpch.hpp
+++ b/NativePlugins/ExternalDynamicLinkLibrary/include/common/edlpch.hpp
@@ -12,6 +12,18 @@
 #endif
 #pragma endregion
 
+#pragma region DLL(P/Invoke)
+#define DLL_EXPORT  extern "C" __declspec(dllexport)
+#define UNITY_API __stdcall
+
+/*
+	@sample
+	DLL_EXPORT <型> UNITY_API <関数名>( 引数 ) { 定義 }
+*/
+
+#pragma endregion
+
+
 #pragma region 変数名:値の出力
 #if DEBUG||_DEBUG
 #define VARARGOUT(var) std::cout<<#var<<":"<<var<<std::endl;
@@ -20,10 +32,10 @@
 #endif // DEBUG||_DEBUG
 #pragma endregion
 
-#ifndef EDL_PCH_HPP
-#define EDL_PCH_HPP
-
-// プリコンパイルするヘッダーをここに追加します
-#include "lua_wrapper.hpp"
-
-#endif //EDL_PCH_HPP
+/*
+	@brief	ダミー処理
+	@detail	P/Invoke用のダミー処理.
+				"dllexport"の定義された関数が一つもないと".lib"が出来ずにリンカーエラーが出る。
+				関数の実装が担保されれば削除してしまっていい.
+*/
+DLL_EXPORT inline void UNITY_API dummy() {}

--- a/NativePlugins/ExternalDynamicLinkLibrary/include/edlpch.cpp
+++ b/NativePlugins/ExternalDynamicLinkLibrary/include/edlpch.cpp
@@ -1,1 +1,0 @@
-#include "edlpch.hpp"

--- a/NativePlugins/ExternalDynamicLinkLibrary/include/lua_wrapper.cpp
+++ b/NativePlugins/ExternalDynamicLinkLibrary/include/lua_wrapper.cpp
@@ -1,28 +1,30 @@
-#include "edlpch.hpp"
 #include<lua.hpp>
+#include<iostream>
+#include"lua_wrapper.hpp"
+
 
 // WIN32APPの場合はprintfがダメそうなのでOutputDebugStringAを使うらしい。
 // ひとまずServer(Linux),Client(x64)なので考えていない.
 
 using namespace std;
 
-CALL lua_wrapper::lua_wrapper()
+ lua_wrapper::lua_wrapper()
 {
 	state = nullptr;
     initialize();
 }
 
-CALL lua_wrapper::~lua_wrapper()
+ lua_wrapper::~lua_wrapper()
 {
     finalize();
 }
 
-void CALL lua_wrapper::initialize()
+void  lua_wrapper::initialize()
 {
 	state = luaL_newstate();
 }
 
-void CALL lua_wrapper::finalize()
+void  lua_wrapper::finalize()
 {
     // スタックに積まれたデータをポップして削除.
     lua_pop(state, lua_gettop(state));
@@ -30,7 +32,7 @@ void CALL lua_wrapper::finalize()
 	state = nullptr;
 }
 
-void CALL lua_wrapper::stack_print(lua_wrapper* wrapper)
+void  lua_wrapper::stack_print(lua_wrapper* wrapper)
 {
     const int num = lua_gettop(wrapper->state);
 
@@ -78,19 +80,36 @@ void CALL lua_wrapper::stack_print(lua_wrapper* wrapper)
     cout << endl;
 }
 
-void CALL lua_wrapper::stack_print()
+void  lua_wrapper::stack_print()
 {
     stack_print(this);
 }
 
-void CALL lua_wrapper::push()
+void  lua_wrapper::push()
 {
     lua_pushnil(state);
-    //return void CALL();
+    //return void ();
 }
 
-void CALL lua_wrapper::push(void* ptr)
+void  lua_wrapper::push(void* ptr)
 {
     //lua_pushboolean(state, ptr);
-    //return void CALL();
+    //return void ();
+}
+
+void lua_wrapper::push(bool value)
+{
+    lua_pushboolean(state, value);
+}
+
+void lua_wrapper::push(double value)
+{
+}
+
+void lua_wrapper::push(const char* value)
+{
+}
+
+void lua_wrapper::push(lua_State* L, int idx)
+{
 }

--- a/NativePlugins/ExternalDynamicLinkLibrary/include/lua_wrapper.hpp
+++ b/NativePlugins/ExternalDynamicLinkLibrary/include/lua_wrapper.hpp
@@ -1,55 +1,44 @@
 #pragma once
 #include<lua.hpp>
-//#define DLL_EXPORT  extern "C" __declspec(dllexport)
-//#define UNITY_API __stdcall
 
-
-// 呼び出し規約をx86/x64で切り替える
-// 64bit
-#if _M_X64
-#define CALL __cdecl
-// 32bit
-#else
-#define CALL
-#endif
 class lua_wrapper 
 {
 public:
-	CALL lua_wrapper();
-	CALL ~lua_wrapper();
-	void CALL initialize();
-	void CALL finalize();
-	static void CALL stack_print(lua_wrapper* warpper);
-	void CALL stack_print();
-	inline lua_State* CALL get_state() { return state; }
+	 lua_wrapper();
+	 ~lua_wrapper();
+	void  initialize();
+	void  finalize();
+	static void  stack_print(lua_wrapper* warpper);
+	void  stack_print();
+	inline lua_State*  get_state() { return state; }
 
 	/*	
 	*	@func	: push
 	*	@brief	: スタックに積む.
 	*	@detail	: nil
 	*/
-	void CALL push();
+	void  push();
 	/*
 	*	@func	: push
 	*	@brief	: スタックに積む.
 	*	@detail	: 軽量ユーザデータ:void*
 	*/
-	void  CALL push(void* ptr);
+	void   push(void* ptr);
 	/*
 	*	@func	: push
 	*	@brief	: スタックに積む.
 	*	@detail	: 真偽値。int型(0, 0以外)
 	*/
-	void CALL push(bool value);
+	void  push(bool value);
 	/*
 	*	@func	: push
 	*	@brief	: スタックに積む.
 	*	@detail	: デフォルトではdouble型
 	*/
-	void CALL push(double value);
+	void  push(double value);
 
-	void CALL push(const char* value);
-	void CALL push(lua_State* L, int idx);
+	void  push(const char* value);
+	void  push(lua_State* L, int idx);
 private:
 	lua_State* state;
 };


### PR DESCRIPTION
## 概要

UnityClient用のNativePlugin(UnmanagedPlugin)作成用のプロジェクトなのに形式が`static library`だった。
Unityで扱えるようにDLL形式に修正。
ネックだったエラーの原因だったのはExteranlDynamicLinkLibraryの追加のライブラリディレクトリのパスに不要な`\`が混じっていたのと`lua`フォルダのパスが抜けていたこと。

## 対応

`static library` → `dll`
`$(SolutionDir)\ExternalDynamicLinkLibrary\dll\$(Platform)` → `$(SolutionDir)$(ProjectName)\dll\$(Platform)\Lua\5.4`
※ついでにExternalDynamicLinkLibraryはプロジェクト名を取るようにした。

## TODO

コンパイルエラーは解消したものの`ExecutionProject`を使ったテスト(dummyのから呼び出しは問題なし)
とUnityCLを利用したテストはしていない。
